### PR TITLE
feat(agents): add session recovery API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Run Python tests with `uv run pytest`; documentation validation requires `uv run --group docs mkdocs build --strict`.
+- `docs/COMPANION_APP_BACKEND.md` is the canonical client API source included by `docs/reference/client-api.md`; edit the canonical source rather than the include file.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ the documentation.
 
 ## [Unreleased]
 
+### Added
+
+- Additive authenticated recovery-v1 reads now return one bounded current
+  session brief, based changes, source-specific retention coverage, and
+  deterministic bidirectional traversal of recent visible and semantic
+  activity. Structured context GET responses are explicitly non-cacheable.
+
 ## [0.1.1] - 2026-07-31
 
 ### Fixed

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -169,6 +169,20 @@ working-directory and source-log metadata are retained locally to associate and
 incrementally read sessions; those internal paths are not returned by the
 public API.
 
+Authenticated recovery reads can combine the current structured brief,
+explicitly based changes, recent visible messages, and recent semantic
+snapshots into one bounded response. The typed activity sequence is assembled
+from those existing normalized records; vmux does not create a second history
+store or a generated account of what happened. Recovery never includes source
+paths or working directories, terminal capture, hidden/encrypted reasoning,
+tool arguments/results, commands, compact summaries, or arbitrary runtime
+records. It does not send chat, resume execution, bind a pane, or acknowledge a
+visit or Review baseline. The response states that model context is owned by
+the runtime and unverified by vmux; it does not claim that a Codex or Claude
+context window was restored. Structured Agent Context and Review GET responses
+carry `Cache-Control: no-store, max-age=0` so conforming clients and
+intermediaries do not retain them.
+
 Historical agent snapshots, messages, and resolved decisions are retained for
 30 days by default. Current context and unresolved decisions can remain while a
 session is active. You can change the retention period, turn off the

--- a/docs/COMPANION_APP_BACKEND.md
+++ b/docs/COMPANION_APP_BACKEND.md
@@ -469,11 +469,12 @@ never "load more" states. Message and semantic coverage are deliberately
 separate. Empty history is valid and has empty arrays plus null cursors.
 Unknown/pruned agents return `404`; disabled Agent Context returns `503`.
 
-Freshness reports the latest matching pane observation time, last projection
-time, and last runtime event time. Request generation time remains separate in
-`generated_at`. Until this server instance has a matching pane observation,
-`observed_at` is null and `runtime_session` is `unknown`; persisted association
-alone never establishes liveness after a restart. `runtime_session` is only
+Freshness reports the latest pane observation correlated with the discovered
+native session after projection, last projection time, and last runtime event
+time. Request generation time remains separate in `generated_at`. Until this
+server instance completes that correlation, `observed_at` is null and
+`runtime_session` is `unknown`; a raw pane observation or persisted association
+alone never establishes liveness. `runtime_session` is only
 `live_bound`, `observed_unbound`, `offline`, or `unknown` and describes
 association to the native runtime session. `model_context` is always
 `runtime_owned_unverified` in v1. A client must never say vmux restored or

--- a/docs/COMPANION_APP_BACKEND.md
+++ b/docs/COMPANION_APP_BACKEND.md
@@ -247,7 +247,18 @@ Returns the live-editable fields plus:
         "persistence": "structured_only",
         "chat": "confirmed_idle_only",
         "decisions": "verified_structured_only",
-        "degraded_reason": null
+        "degraded_reason": null,
+        "recovery": {
+          "version": 1,
+          "path_template": "/api/agents/{id}/recovery",
+          "default_recent_messages": 20,
+          "default_recent_timeline": 20,
+          "default_recent_activity": 20,
+          "max_recent_messages": 50,
+          "max_recent_timeline": 50,
+          "max_recent_activity": 50,
+          "activity_order": "oldest_to_newest"
+        }
       },
       "agent_review_v1": {
         "enabled": true,
@@ -274,8 +285,11 @@ currently represented tmux targets. Push and usage info report
 capability/availability without exposing credentials.
 
 `capabilities.agent_context_v1` gates the independent agent workspace, and
-`capabilities.agent_review_v1` gates the cross-client Review workflow. Clients
-must fall back to the terminal workspace when it is absent or disabled.
+`capabilities.agent_review_v1` gates the cross-client Review workflow. The
+optional `agent_context_v1.recovery` object advertises the additive recovery-v1
+read; clients that do not understand it ignore it, and newer clients use the
+legacy resources when it is absent. Clients must fall back to the terminal
+workspace when Agent Context is absent or disabled.
 `experimental_agent_workspace_enabled` is the authoritative server-persisted
 switch; clients must not hydrate agent REST resources or open `/ws/agents`
 unless it is `true` and the corresponding capability is enabled.
@@ -299,6 +313,7 @@ accepts `status` and `agent_id` filters.
 | `GET /api/agents` | `{agents:[AgentSession],next_cursor}` |
 | `GET /api/agents/{id}` | Current `AgentSession` |
 | `GET /api/agents/{id}/resume` | Resume object shown below |
+| `GET /api/agents/{id}/recovery` | One bounded current brief, based changes, visible-message page, semantic page, and traversable typed activity page |
 | `PUT /api/agents/{id}/visit` | Advance the shared baseline with `{"snapshot_id":"..."}` |
 | `GET /api/agents/{id}/timeline` | `{events:[TimelineEvent],next_cursor}`; events include their context |
 | `GET /api/timeline` | `{events:[TimelineEvent],next_cursor}` across sessions; event context is `null` |
@@ -387,6 +402,85 @@ accept either during the v1 transition. Other context fields, including
 than being duplicated at the top level. A change object may omit any unchanged
 key. `history_truncated` means the saved visit baseline expired before the
 oldest retained snapshot, so the delta starts at the oldest available context.
+
+### Recovery v1
+
+When `agent_context_v1.recovery.version` is `1`, an authenticated client can
+fetch:
+
+~~~http
+GET /api/agents/{id}/recovery?message_limit=20&timeline_limit=20&activity_limit=20
+~~~
+
+The canonical cross-client contract fixture is
+[`recovery-v1.fixture.json`](recovery-v1.fixture.json). The response
+contains the current public `agent` (the structured session brief), `changes`,
+`recent_messages`, `recent_timeline`, `recent_activity`, and `freshness`.
+`generated_at`, `server_instance_id`, and `consistency: "single_read"` identify
+the observation. All sections are selected inside one SQLite read transaction;
+a projection committed afterward is delivered by normal invalidation and will
+appear on a later GET.
+
+Recovery is a read, not an execution operation. It never sends chat, resumes a
+runtime, binds a pane, observes logs, or advances the legacy visit, Review, or
+any client read baseline. The current brief and `changes.delta` are existing
+normalized data, not a server-authored narrative. `changes.basis` is
+`shared_review` when that baseline exists, otherwise `legacy_shared_visit`,
+otherwise `available_history`. `changes.history_truncated` and
+`changes.unavailable_reason: "expired_or_deleted"` describe a missing semantic
+change basis; they do not describe visible-message retention.
+
+The two source pages remain independently useful:
+
+- `recent_messages.messages` contains retained visible user/assistant messages;
+- `recent_timeline.events` contains retained semantic snapshots; and
+- each page is chronological (`oldest_to_newest`), has an older `next_cursor`,
+  a newer `previous_cursor`, `cursor_status`, and source-specific `coverage`.
+
+`recent_activity.entries` is the deterministic presentation sequence. Each
+entry is a discriminated resource with `kind: "visible_message"` or
+`kind: "semantic_event"`, `occurred_at`, stable resource id, and the existing
+normalized resource. The order key is ascending
+`(occurred_at, kind, source_order, resource_id)`: visible messages sort before
+semantic events when timestamps tie; retained message insertion order or
+semantic snapshot sequence breaks same-kind ties; the id is the final stable
+tie-breaker. This order is independent of arrival order and does not fabricate
+or infer activity text.
+
+The newest request has no activity cursor. `older_cursor` loads the immediately
+older retained page and `newer_cursor` loads the immediately newer retained
+page; every returned page is still chronological. Cursors are opaque keyset
+values scoped to the agent and resource. The first request records immutable
+message/snapshot high-water marks and a read time. Every cursor derived from
+that page retains those anchors, so a concurrent projection—even one carrying
+an older runtime timestamp—cannot duplicate, reorder, or enter the traversal.
+Cursors survive a server restart because they require no process-local state.
+They remain usable while their anchored records are retained. A deletion or
+retention pass can make a boundary unavailable; an empty page then reports
+`cursor_status: "data_unavailable"` or `"exhausted"`, and the client should
+show the coverage warning or refetch the newest page rather than call the
+history complete.
+
+Limits are clamped to `1...50`; malformed cursor syntax returns `400`.
+`more_retained_older`/`more_retained_newer` and non-null cursors mean data is
+still available and are never retention warnings. `history_truncated` and
+`unavailable_reason` mean earlier source data expired or was deleted and are
+never "load more" states. Message and semantic coverage are deliberately
+separate. Empty history is valid and has empty arrays plus null cursors.
+Unknown/pruned agents return `404`; disabled Agent Context returns `503`.
+
+Freshness reports server observation time, last projection time, and last
+runtime event time. `runtime_session` is only `live_bound`, `observed_unbound`,
+`offline`, or `unknown` and describes association to the native runtime
+session. `model_context` is always `runtime_owned_unverified` in v1. A client
+must never say vmux restored or verified the runtime/model context window.
+
+Every structured Agent Context, Timeline, Decision, and Review GET response,
+including authentication/domain errors, carries `Cache-Control: no-store,
+max-age=0`. Recovery contains no pane capture, source path/CWD, hidden or
+encrypted reasoning, compact summaries, tool arguments/results, commands, or
+arbitrary runtime records. Its only text is already-public structured context,
+visible messages, and normalized semantic metadata.
 
 ### Review workflow
 

--- a/docs/COMPANION_APP_BACKEND.md
+++ b/docs/COMPANION_APP_BACKEND.md
@@ -469,11 +469,15 @@ never "load more" states. Message and semantic coverage are deliberately
 separate. Empty history is valid and has empty arrays plus null cursors.
 Unknown/pruned agents return `404`; disabled Agent Context returns `503`.
 
-Freshness reports server observation time, last projection time, and last
-runtime event time. `runtime_session` is only `live_bound`, `observed_unbound`,
-`offline`, or `unknown` and describes association to the native runtime
-session. `model_context` is always `runtime_owned_unverified` in v1. A client
-must never say vmux restored or verified the runtime/model context window.
+Freshness reports the latest matching pane observation time, last projection
+time, and last runtime event time. Request generation time remains separate in
+`generated_at`. Until this server instance has a matching pane observation,
+`observed_at` is null and `runtime_session` is `unknown`; persisted association
+alone never establishes liveness after a restart. `runtime_session` is only
+`live_bound`, `observed_unbound`, `offline`, or `unknown` and describes
+association to the native runtime session. `model_context` is always
+`runtime_owned_unverified` in v1. A client must never say vmux restored or
+verified the runtime/model context window.
 
 Every structured Agent Context, Timeline, Decision, and Review GET response,
 including authentication/domain errors, carries `Cache-Control: no-store,

--- a/docs/COMPANION_APP_BACKEND.md
+++ b/docs/COMPANION_APP_BACKEND.md
@@ -475,7 +475,8 @@ time. Request generation time remains separate in `generated_at`. Until this
 server instance completes that correlation, `observed_at` is null and
 `runtime_session` is `unknown`; a raw pane observation or persisted association
 alone never establishes liveness. If the observation generation changes during
-the consistent store read, freshness is downgraded to unknown.
+the consistent store read, or its age exceeds the poll-relative liveness
+boundary, freshness is downgraded to unknown.
 `runtime_session` is only `live_bound`, `observed_unbound`, `offline`, or
 `unknown` and describes association to the native runtime session.
 `model_context` is always

--- a/docs/COMPANION_APP_BACKEND.md
+++ b/docs/COMPANION_APP_BACKEND.md
@@ -474,9 +474,11 @@ native session after projection, last projection time, and last runtime event
 time. Request generation time remains separate in `generated_at`. Until this
 server instance completes that correlation, `observed_at` is null and
 `runtime_session` is `unknown`; a raw pane observation or persisted association
-alone never establishes liveness. `runtime_session` is only
-`live_bound`, `observed_unbound`, `offline`, or `unknown` and describes
-association to the native runtime session. `model_context` is always
+alone never establishes liveness. If the observation generation changes during
+the consistent store read, freshness is downgraded to unknown.
+`runtime_session` is only `live_bound`, `observed_unbound`, `offline`, or
+`unknown` and describes association to the native runtime session.
+`model_context` is always
 `runtime_owned_unverified` in v1. A client must never say vmux restored or
 verified the runtime/model context window.
 

--- a/docs/COMPANION_APP_BACKEND.md
+++ b/docs/COMPANION_APP_BACKEND.md
@@ -428,7 +428,10 @@ normalized data, not a server-authored narrative. `changes.basis` is
 `shared_review` when that baseline exists, otherwise `legacy_shared_visit`,
 otherwise `available_history`. `changes.history_truncated` and
 `changes.unavailable_reason: "expired_or_deleted"` describe a missing semantic
-change basis; they do not describe visible-message retention.
+change basis; they do not describe visible-message retention. A truncated
+`available_history` delta begins at the oldest retained snapshot. If no
+snapshot remains, the delta is empty rather than inferred from an invented
+empty context.
 
 The two source pages remain independently useful:
 

--- a/docs/guides/agent-context.md
+++ b/docs/guides/agent-context.md
@@ -82,6 +82,33 @@ remaining snapshot. The exact response and mutation schemas are in the
 **Resume** is deliberately non-mutating: it opens and focuses chat but never
 sends a message or resumes terminal execution on its own.
 
+## Session recovery and recent activity
+
+Recovery-capable clients use the advertised authenticated
+`GET /api/agents/{id}/recovery` resource. It returns one bounded SQLite read of
+the current brief, explicitly based changes, retained visible conversation,
+semantic snapshots, freshness, and a typed activity sequence that can be paged
+older or newer. Opening or traversing recovery is non-mutating: it does not
+send, resume, bind, observe, or advance visit/Review/read state.
+
+Visible-message and semantic-history gaps are reported separately. A cursor or
+`more_retained_*` value means retained data can still be loaded; it never means
+history was lost. `history_truncated` with `expired_or_deleted` means earlier
+data in that specific source is unavailable. Opaque recovery cursors pin the
+first page's high-water marks, remain valid across process restarts while data
+is retained, and prevent concurrent or out-of-order projection from entering an
+in-progress traversal.
+
+The activity page is always chronological. Timestamp ties use resource kind,
+then retained source order, then resource id, so a client can render the same
+sequence without inventing prose. See the complete contract and canonical JSON
+fixture in [the companion API](../reference/client-api.md#recovery-v1).
+
+Recovery can restore only vmux's retained structured resources. Its model
+context state is always `runtime_owned_unverified` in v1: vmux cannot verify
+that Codex or Claude restored, retained, compacted, or forgot its model context
+window.
+
 ## Review sessions
 
 Review combines changes across structured sessions with privacy-minimized

--- a/docs/reference/recovery-v1.fixture.json
+++ b/docs/reference/recovery-v1.fixture.json
@@ -1,0 +1,227 @@
+{
+  "version": 1,
+  "generated_at": 1788040800.0,
+  "server_instance_id": "server-fixture",
+  "consistency": "single_read",
+  "agent": {
+    "id": "agent-fixture",
+    "runtime": "codex",
+    "native_session_id": "native-session-fixture",
+    "title": "Recovery API",
+    "lifecycle": "working",
+    "association": "confirmed",
+    "pane_id": "%7",
+    "target": "work:1.0",
+    "binding_revision": 4,
+    "revision": 12,
+    "capabilities": {
+      "association": "confirmed",
+      "context": "structured",
+      "chat_send": "idle_only",
+      "decision_reply": "verified_terminal",
+      "delivery_ack": "log_observed"
+    },
+    "extraction_health": "ok",
+    "last_event_at": 1788040797.0,
+    "created_at": 1788030000.0,
+    "updated_at": 1788040798.0,
+    "context": {
+      "session_id": "agent-fixture",
+      "runtime": "codex",
+      "goal": "Ship recovery",
+      "current_task": "Validate deterministic traversal",
+      "progress_summary": "The bounded backend contract is implemented.",
+      "completed_items": [],
+      "decisions": [],
+      "blockers": [],
+      "next_action": "Review the iOS integration",
+      "progress": null,
+      "estimated_completion": null,
+      "lifecycle": "working",
+      "extraction_health": "ok",
+      "revision": 12,
+      "last_updated": 1788040797.0,
+      "provenance": {}
+    },
+    "pending_decisions_count": 0
+  },
+  "changes": {
+    "basis": "shared_review",
+    "baseline_snapshot_id": "snapshot-10",
+    "as_of_snapshot_id": "snapshot-12",
+    "history_truncated": false,
+    "unavailable_reason": null,
+    "delta": {
+      "current_task_changed": {
+        "from": "Implement recovery",
+        "to": "Validate deterministic traversal"
+      }
+    }
+  },
+  "recent_messages": {
+    "order": "oldest_to_newest",
+    "messages": [
+      {
+        "id": "message-12",
+        "agent_id": "agent-fixture",
+        "role": "assistant",
+        "content": "The bounded backend contract is implemented.",
+        "status": "observed",
+        "native_event_id": "visible-12",
+        "client_message_id": null,
+        "created_at": 1788040796.0,
+        "updated_at": 1788040798.0
+      }
+    ],
+    "next_cursor": "rc1.opaque-older-message-cursor",
+    "previous_cursor": null,
+    "cursor_status": "current",
+    "coverage": {
+      "retained_from": 1788030001.0,
+      "retained_to": 1788040796.0,
+      "history_truncated": false,
+      "unavailable_reason": null,
+      "more_retained_older": true,
+      "more_retained_newer": false
+    }
+  },
+  "recent_timeline": {
+    "order": "oldest_to_newest",
+    "events": [
+      {
+        "id": "snapshot-12",
+        "agent_id": "agent-fixture",
+        "sequence": 12,
+        "created_at": 1788040798.0,
+        "occurred_at": 1788040798.0,
+        "delta": {
+          "current_task_changed": {
+            "from": "Implement recovery",
+            "to": "Validate deterministic traversal"
+          }
+        },
+        "context": {
+          "session_id": "agent-fixture",
+          "runtime": "codex",
+          "goal": "Ship recovery",
+          "current_task": "Validate deterministic traversal",
+          "progress_summary": "The bounded backend contract is implemented.",
+          "completed_items": [],
+          "decisions": [],
+          "blockers": [],
+          "next_action": "Review the iOS integration",
+          "progress": null,
+          "estimated_completion": null,
+          "lifecycle": "working",
+          "extraction_health": "ok",
+          "revision": 12,
+          "last_updated": 1788040797.0,
+          "provenance": {}
+        },
+        "type": "context",
+        "title": "Agent context changed"
+      }
+    ],
+    "next_cursor": "rc1.opaque-older-timeline-cursor",
+    "previous_cursor": null,
+    "cursor_status": "current",
+    "coverage": {
+      "retained_from": 1788030002.0,
+      "retained_to": 1788040798.0,
+      "history_truncated": false,
+      "unavailable_reason": null,
+      "more_retained_older": true,
+      "more_retained_newer": false
+    }
+  },
+  "recent_activity": {
+    "order": "oldest_to_newest",
+    "tie_break": "occurred_at_kind_source_order_resource_id",
+    "entries": [
+      {
+        "id": "visible_message:message-12",
+        "kind": "visible_message",
+        "occurred_at": 1788040796.0,
+        "resource_id": "message-12",
+        "resource": {
+          "id": "message-12",
+          "agent_id": "agent-fixture",
+          "role": "assistant",
+          "content": "The bounded backend contract is implemented.",
+          "status": "observed",
+          "native_event_id": "visible-12",
+          "client_message_id": null,
+          "created_at": 1788040796.0,
+          "updated_at": 1788040798.0
+        }
+      },
+      {
+        "id": "semantic_event:snapshot-12",
+        "kind": "semantic_event",
+        "occurred_at": 1788040798.0,
+        "resource_id": "snapshot-12",
+        "resource": {
+          "id": "snapshot-12",
+          "agent_id": "agent-fixture",
+          "sequence": 12,
+          "created_at": 1788040798.0,
+          "occurred_at": 1788040798.0,
+          "delta": {
+            "current_task_changed": {
+              "from": "Implement recovery",
+              "to": "Validate deterministic traversal"
+            }
+          },
+          "context": {
+            "session_id": "agent-fixture",
+            "runtime": "codex",
+            "goal": "Ship recovery",
+            "current_task": "Validate deterministic traversal",
+            "progress_summary": "The bounded backend contract is implemented.",
+            "completed_items": [],
+            "decisions": [],
+            "blockers": [],
+            "next_action": "Review the iOS integration",
+            "progress": null,
+            "estimated_completion": null,
+            "lifecycle": "working",
+            "extraction_health": "ok",
+            "revision": 12,
+            "last_updated": 1788040797.0,
+            "provenance": {}
+          },
+          "type": "context",
+          "title": "Agent context changed"
+        }
+      }
+    ],
+    "older_cursor": "rc1.opaque-older-activity-cursor",
+    "newer_cursor": null,
+    "cursor_status": "current",
+    "coverage": {
+      "visible_messages": {
+        "retained_from": 1788030001.0,
+        "retained_to": 1788040796.0,
+        "history_truncated": false,
+        "unavailable_reason": null,
+        "more_retained_older": true,
+        "more_retained_newer": false
+      },
+      "semantic_history": {
+        "retained_from": 1788030002.0,
+        "retained_to": 1788040798.0,
+        "history_truncated": false,
+        "unavailable_reason": null,
+        "more_retained_older": true,
+        "more_retained_newer": false
+      }
+    }
+  },
+  "freshness": {
+    "observed_at": 1788040800.0,
+    "projected_at": 1788040798.0,
+    "last_runtime_event_at": 1788040797.0,
+    "runtime_session": "live_bound",
+    "model_context": "runtime_owned_unverified"
+  }
+}

--- a/tests/test_experimental_workspace.py
+++ b/tests/test_experimental_workspace.py
@@ -140,8 +140,7 @@ def test_successful_switch_change_invalidates_other_pwa_config_clients(
                 json={"experimental_agent_workspace_enabled": True},
             )
             assert response.status_code == 200
-            messages = [websocket.receive_json() for _ in range(3)]
-            assert "config_changed" in {message["type"] for message in messages}
+            assert websocket.receive_json()["type"] == "config_changed"
 
 
 def test_failed_disable_persistence_restores_enabled_runtime(tmp_path, monkeypatch):

--- a/tests/test_poller_live_updates.py
+++ b/tests/test_poller_live_updates.py
@@ -12,7 +12,6 @@ from vmux.config import Config
 from vmux.models import PaneState
 from vmux.poller import Hub
 
-
 PANE = {
     "id": "%1", "target": "work:1.1", "cmd": "node", "title": "worker",
     "window": "work", "path": "/tmp", "pid": "", "window_id": "@1",

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -441,8 +441,28 @@ def test_observer_to_recovery_excludes_hidden_tool_terminal_and_path_data(tmp_pa
         prompt_fingerprint=observation.prompt_fingerprint,
         observed_at=observation.observed_at + 1,
     )
+    entered = threading.Event()
+    release = threading.Event()
+    original_recovery = service.store.recovery
+
+    def paused_recovery(*args, **kwargs):
+        value = original_recovery(*args, **kwargs)
+        entered.set()
+        assert release.wait(1)
+        return value
+
+    service.store.recovery = paused_recovery
+    raced_recoveries = []
+    thread = threading.Thread(
+        target=lambda: raced_recoveries.append(service.recovery(agent["id"]))
+    )
+    thread.start()
+    assert entered.wait(1)
     service.submit([newer_raw_observation])
-    unverified = service.recovery(agent["id"])["freshness"]
+    release.set()
+    thread.join(1)
+    assert not thread.is_alive()
+    unverified = raced_recoveries[0]["freshness"]
     assert unverified["observed_at"] is None
     assert unverified["runtime_session"] == "unknown"
 

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -312,6 +312,28 @@ def test_recovery_reports_message_and_semantic_gaps_independently(tmp_path):
     assert limited["recent_messages"]["coverage"]["unavailable_reason"] == "expired_or_deleted"
 
 
+def test_old_session_age_does_not_claim_visible_message_loss(tmp_path):
+    store = AgentStore(str(tmp_path / "agents.sqlite3"), retention_days=1)
+    empty = _agent(store, native="old-empty")
+    recent = _agent(store, native="old-recent")
+    old_created_at = time.time() - 2 * 86400
+    with store.transaction() as conn:
+        conn.execute(
+            "UPDATE agent_sessions SET created_at=? WHERE id IN (?,?)",
+            (old_created_at, empty["id"], recent["id"]),
+        )
+    _project(store, recent["id"], 1, message_time=time.time())
+
+    for agent_id in (empty["id"], recent["id"]):
+        recovery_coverage = store.recovery(agent_id)["recent_messages"]["coverage"]
+        assert recovery_coverage["history_truncated"] is False
+        assert recovery_coverage["unavailable_reason"] is None
+        _, _, message_metadata = store.list_messages(
+            agent_id, with_metadata=True
+        )
+        assert message_metadata["history_truncated"] is False
+
+
 def test_observer_to_recovery_excludes_hidden_tool_terminal_and_path_data(tmp_path):
     from vmux.agents.models import PaneObservation
     from vmux.agents.service import AgentService
@@ -387,7 +409,10 @@ def test_observer_to_recovery_excludes_hidden_tool_terminal_and_path_data(tmp_pa
     )
     asyncio.run(service.process_now([observation]))
     agent = service.list_agents()[0][0]
-    encoded = json.dumps(service.recovery(agent["id"]), sort_keys=True)
+    recovery = service.recovery(agent["id"])
+    assert recovery["freshness"]["observed_at"] == observation.observed_at
+    assert recovery["freshness"]["runtime_session"] == "live_bound"
+    encoded = json.dumps(recovery, sort_keys=True)
     assert "Visible recovery request" in encoded
     assert "Visible recovery answer" in encoded
     for prohibited in (
@@ -400,6 +425,26 @@ def test_observer_to_recovery_excludes_hidden_tool_terminal_and_path_data(tmp_pa
         "TERMINAL_PROMPT_CANARY",
     ):
         assert prohibited not in encoded
+
+    newer_raw_observation = PaneObservation(
+        pane_id=observation.pane_id,
+        target=observation.target,
+        command=observation.command,
+        title=observation.title,
+        cwd=observation.cwd,
+        pid=observation.pid,
+        pane_created=observation.pane_created,
+        runtime=observation.runtime,
+        status=observation.status,
+        question=observation.question,
+        menu=observation.menu,
+        prompt_fingerprint=observation.prompt_fingerprint,
+        observed_at=observation.observed_at + 1,
+    )
+    service.submit([newer_raw_observation])
+    unverified = service.recovery(agent["id"])["freshness"]
+    assert unverified["observed_at"] is None
+    assert unverified["runtime_session"] == "unknown"
 
 
 def test_deleted_cursor_never_projects_future_history_and_private_metadata_is_absent(tmp_path):
@@ -498,7 +543,7 @@ def test_recovery_api_is_authenticated_advertised_no_store_and_clamps_limits(tmp
         assert malformed.headers["cache-control"] == "no-store, max-age=0"
 
 
-def test_recovery_freshness_requires_a_matching_current_process_observation(tmp_path):
+def test_recovery_freshness_rejects_uncorrelated_and_previous_process_observations(tmp_path):
     from vmux.agents.models import PaneObservation, default_capabilities
     from vmux.agents.service import AgentService
     from vmux.config import Config
@@ -542,10 +587,9 @@ def test_recovery_freshness_requires_a_matching_current_process_observation(tmp_
     assert before_observation["runtime_session"] == "unknown"
 
     service.submit([observation])
-    observed = service.recovery(agent["id"])["freshness"]
-    assert observed["observed_at"] == observed_at
-    assert observed["runtime_session"] == "live_bound"
-    assert observed["observed_at"] != service.recovery(agent["id"])["generated_at"]
+    uncorrelated = service.recovery(agent["id"])["freshness"]
+    assert uncorrelated["observed_at"] is None
+    assert uncorrelated["runtime_session"] == "unknown"
 
     restarted = AgentService(cfg)
     after_restart = restarted.recovery(agent["id"])["freshness"]

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -312,6 +312,33 @@ def test_recovery_reports_message_and_semantic_gaps_independently(tmp_path):
     assert limited["recent_messages"]["coverage"]["unavailable_reason"] == "expired_or_deleted"
 
 
+def test_truncated_available_history_uses_oldest_retained_change_baseline(tmp_path):
+    store = AgentStore(str(tmp_path / "agents.sqlite3"))
+    agent = _agent(store)
+    now = time.time()
+    first = _project(store, agent["id"], 1, message_time=now)
+    _project(store, agent["id"], 2, message_time=now + 1)
+    _project(store, agent["id"], 3, message_time=now + 2)
+    with store.transaction() as conn:
+        conn.execute("DELETE FROM agent_snapshots WHERE id=?", (first["id"],))
+
+    changes = store.recovery(agent["id"])["changes"]
+    assert changes["basis"] == "available_history"
+    assert changes["history_truncated"] is True
+    assert changes["unavailable_reason"] == "expired_or_deleted"
+    assert "goal_changed" not in changes["delta"]
+    assert changes["delta"]["current_task_changed"] == {
+        "from": "step-2",
+        "to": "step-3",
+    }
+
+    with store.transaction() as conn:
+        conn.execute("DELETE FROM agent_snapshots WHERE session_id=?", (agent["id"],))
+    no_history = store.recovery(agent["id"])["changes"]
+    assert no_history["history_truncated"] is True
+    assert no_history["delta"] == {}
+
+
 def test_old_session_age_does_not_claim_visible_message_loss(tmp_path):
     store = AgentStore(str(tmp_path / "agents.sqlite3"), retention_days=1)
     empty = _agent(store, native="old-empty")

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -426,6 +426,27 @@ def test_observer_to_recovery_excludes_hidden_tool_terminal_and_path_data(tmp_pa
     ):
         assert prohibited not in encoded
 
+    stale_observation = PaneObservation(
+        pane_id=observation.pane_id,
+        target=observation.target,
+        command=observation.command,
+        title=observation.title,
+        cwd=observation.cwd,
+        pid=observation.pid,
+        pane_created=observation.pane_created,
+        runtime=observation.runtime,
+        status=observation.status,
+        question=observation.question,
+        menu=observation.menu,
+        prompt_fingerprint=observation.prompt_fingerprint,
+        observed_at=time.time() - 11,
+    )
+    asyncio.run(service.process_now([stale_observation]))
+    stale = service.recovery(agent["id"])["freshness"]
+    assert stale["observed_at"] is None
+    assert stale["runtime_session"] == "unknown"
+    asyncio.run(service.process_now([observation]))
+
     newer_raw_observation = PaneObservation(
         pane_id=observation.pane_id,
         target=observation.target,

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -492,10 +492,65 @@ def test_recovery_api_is_authenticated_advertised_no_store_and_clamps_limits(tmp
         malformed = client.get(
             "/api/agents/%s/recovery" % agent["id"],
             headers=auth,
-            params={"activity_cursor": "bad"},
+            params={"activity_cursor": "rc1." + "a" * 1001},
         )
         assert malformed.status_code == 400
         assert malformed.headers["cache-control"] == "no-store, max-age=0"
+
+
+def test_recovery_freshness_requires_a_matching_current_process_observation(tmp_path):
+    from vmux.agents.models import PaneObservation, default_capabilities
+    from vmux.agents.service import AgentService
+    from vmux.config import Config
+
+    cfg = Config(
+        experimental_agent_workspace_enabled=True,
+        agent_store_path=str(tmp_path / "freshness.sqlite3"),
+    )
+    service = AgentService(cfg)
+    agent = _agent(service.store, native="freshness")
+    observed_at = time.time() - 5
+    observation = PaneObservation(
+        pane_id="%9",
+        target="work:1.0",
+        command="codex",
+        title="private terminal title",
+        cwd="/private/worktree/SECRET-cwd",
+        pid="9",
+        pane_created=observed_at - 10,
+        runtime="codex",
+        status="idle",
+        question=None,
+        menu=(),
+        prompt_fingerprint="private-fingerprint",
+        observed_at=observed_at,
+    )
+    service.store.update_binding(
+        agent["id"],
+        association="confirmed",
+        pane_id=observation.pane_id,
+        target=observation.target,
+        pane_pid=observation.pid,
+        pane_created=observation.pane_created,
+        pane_incarnation=observation.incarnation,
+        source="automatic",
+        capabilities=default_capabilities("confirmed"),
+    )
+
+    before_observation = service.recovery(agent["id"])["freshness"]
+    assert before_observation["observed_at"] is None
+    assert before_observation["runtime_session"] == "unknown"
+
+    service.submit([observation])
+    observed = service.recovery(agent["id"])["freshness"]
+    assert observed["observed_at"] == observed_at
+    assert observed["runtime_session"] == "live_bound"
+    assert observed["observed_at"] != service.recovery(agent["id"])["generated_at"]
+
+    restarted = AgentService(cfg)
+    after_restart = restarted.recovery(agent["id"])["freshness"]
+    assert after_restart["observed_at"] is None
+    assert after_restart["runtime_session"] == "unknown"
 
 
 def test_canonical_recovery_fixture_tracks_the_discriminated_contract():

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,564 @@
+"""Recovery-v1 consistency, traversal, retention, and privacy contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+
+from vmux.agents.store import MAX_RECOVERY_ITEMS, AgentStore
+
+
+def _agent(store: AgentStore, native: str = "native"):
+    return store.upsert_session(
+        "codex",
+        native,
+        "/private/source/SECRET-log.jsonl",
+        "/private/worktree/SECRET-cwd",
+        "v1",
+    )
+
+
+def _project(store: AgentStore, agent_id: str, index: int, *, message_time: float):
+    context = dict(store.get_agent(agent_id)["context"])
+    context.update(
+        {
+            "goal": "Ship recovery",
+            "current_task": "step-%d" % index,
+            "next_action": "next-%d" % index,
+            "last_updated": message_time,
+        }
+    )
+    return store.apply_projection(
+        agent_id,
+        context,
+        [
+            {
+                "native_event_id": "visible-%d" % index,
+                "role": "user" if index % 2 else "assistant",
+                "content": "visible message %d" % index,
+                "status": "observed",
+                "created_at": message_time,
+            }
+        ],
+        [],
+        [],
+    )[0]
+
+
+def _all_older_pages(store: AgentStore, agent_id: str, first: dict, limit: int):
+    pages = [first["entries"]]
+    cursor = first["older_cursor"]
+    while cursor:
+        page = store.recovery(
+            agent_id, activity_limit=limit, activity_cursor=cursor
+        )["recent_activity"]
+        pages.append(page["entries"])
+        cursor = page["older_cursor"]
+    # The default page is newest; each individual page is chronological.
+    return [entry for page in reversed(pages) for entry in page]
+
+
+def test_recovery_activity_is_bounded_typed_and_deterministic_across_ties(
+    tmp_path, monkeypatch
+):
+    fixed = time.time()
+    monkeypatch.setattr("vmux.agents.store.time.time", lambda: fixed)
+    store = AgentStore(str(tmp_path / "agents.sqlite3"))
+    agent = _agent(store)
+    for index in range(1, 7):
+        _project(store, agent["id"], index, message_time=fixed)
+    # A duplicate/out-of-order source event remains one retained resource.
+    context = dict(store.get_agent(agent["id"])["context"])
+    store.apply_projection(
+        agent["id"],
+        context,
+        [{
+            "native_event_id": "visible-1",
+            "role": "user",
+            "content": "duplicate must not cross recovery",
+            "status": "observed",
+            "created_at": fixed - 100,
+        }],
+        [],
+        [],
+    )
+
+    response = store.recovery(
+        agent["id"], message_limit=999, timeline_limit=999, activity_limit=3
+    )
+    assert response["consistency"] == "single_read"
+    assert response["freshness"]["model_context"] == "runtime_owned_unverified"
+    assert len(response["recent_messages"]["messages"]) <= MAX_RECOVERY_ITEMS
+    assert len(response["recent_timeline"]["events"]) <= MAX_RECOVERY_ITEMS
+    activity = response["recent_activity"]
+    assert activity["order"] == "oldest_to_newest"
+    assert activity["tie_break"] == "occurred_at_kind_source_order_resource_id"
+
+    pages = [activity]
+    while pages[-1]["older_cursor"]:
+        pages.append(
+            store.recovery(
+                agent["id"],
+                activity_limit=3,
+                activity_cursor=pages[-1]["older_cursor"],
+            )["recent_activity"]
+        )
+    entries = [entry for page in reversed(pages) for entry in page["entries"]]
+    ids = [entry["id"] for entry in entries]
+    assert len(ids) == len(set(ids)) == 12
+    assert {entry["kind"] for entry in entries} == {
+        "visible_message",
+        "semantic_event",
+    }
+    # At equal timestamps, visible messages sort before semantic snapshots;
+    # source insertion order then breaks ties within each kind.
+    assert [entry["kind"] for entry in entries] == [
+        *(["visible_message"] * 6),
+        *(["semantic_event"] * 6),
+    ]
+    assert "duplicate must not cross recovery" not in json.dumps(response)
+    # Starting at the oldest page, newer cursors deterministically return to
+    # the original newest page without repeating a resource.
+    newer_pages = [pages[-1]]
+    while newer_pages[-1]["newer_cursor"]:
+        newer_pages.append(
+            store.recovery(
+                agent["id"],
+                activity_limit=3,
+                activity_cursor=newer_pages[-1]["newer_cursor"],
+            )["recent_activity"]
+        )
+    newer_ids = [entry["id"] for page in newer_pages for entry in page["entries"]]
+    assert len(newer_ids) == len(set(newer_ids)) == 12
+    assert newer_ids == ids
+
+
+def test_recovery_long_session_remains_bounded_without_skips(tmp_path):
+    store = AgentStore(str(tmp_path / "agents.sqlite3"))
+    agent = _agent(store)
+    now = time.time()
+    for index in range(75):
+        _project(store, agent["id"], index, message_time=now + index / 1000)
+    newest = store.recovery(agent["id"], activity_limit=100000)["recent_activity"]
+    assert len(newest["entries"]) == MAX_RECOVERY_ITEMS
+    entries = _all_older_pages(store, agent["id"], newest, MAX_RECOVERY_ITEMS)
+    assert len(entries) == 150
+    assert len({entry["id"] for entry in entries}) == 150
+    assert [entry["occurred_at"] for entry in entries] == sorted(
+        entry["occurred_at"] for entry in entries
+    )
+    assert len(store.recovery(agent["id"], activity_limit=0)["recent_activity"]["entries"]) == 1
+
+
+def test_recovery_cursor_anchor_excludes_concurrent_projection_and_survives_restart(
+    tmp_path
+):
+    path = tmp_path / "agents.sqlite3"
+    store = AgentStore(str(path))
+    agent = _agent(store)
+    now = time.time()
+    for index in range(1, 5):
+        _project(store, agent["id"], index, message_time=now + index)
+    first = store.recovery(agent["id"], activity_limit=2)["recent_activity"]
+    assert first["older_cursor"]
+
+    new_snapshot = _project(store, agent["id"], 5, message_time=now - 500)
+    anchored = _all_older_pages(store, agent["id"], first, 2)
+    anchored_ids = {entry["resource_id"] for entry in anchored}
+    assert new_snapshot["id"] not in anchored_ids
+    assert "visible-5" not in {
+        entry["resource"].get("native_event_id") for entry in anchored
+    }
+    latest_ids = {
+        entry["resource_id"]
+        for entry in _all_older_pages(
+            store,
+            agent["id"],
+            store.recovery(agent["id"], activity_limit=2)["recent_activity"],
+            2,
+        )
+    }
+    assert new_snapshot["id"] in latest_ids
+
+    cursor = first["older_cursor"]
+    expected_page_ids = [
+        entry["id"]
+        for entry in store.recovery(
+            agent["id"], activity_limit=2, activity_cursor=cursor
+        )["recent_activity"]["entries"]
+    ]
+    store.close()
+    reopened = AgentStore(str(path))
+    page = reopened.recovery(
+        agent["id"], activity_limit=2, activity_cursor=cursor
+    )["recent_activity"]
+    assert page["cursor_status"] == "valid"
+    assert [entry["id"] for entry in page["entries"]] == expected_page_ids
+
+
+def test_recovery_single_read_cannot_mix_a_concurrent_projection(tmp_path):
+    store = AgentStore(str(tmp_path / "agents.sqlite3"))
+    agent = _agent(store)
+    now = time.time()
+    before_snapshot = _project(store, agent["id"], 1, message_time=now)
+    entered = threading.Event()
+    writer_started = threading.Event()
+    release = threading.Event()
+    original_page = store._recovery_page
+    calls = 0
+
+    def paused_page(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            entered.set()
+            assert writer_started.wait(1)
+            # The writer has attempted projection but cannot acquire the store
+            # lock until this complete read transaction releases it.
+            assert not release.wait(0.05)
+        return original_page(*args, **kwargs)
+
+    store._recovery_page = paused_page
+    projected = []
+
+    def writer():
+        assert entered.wait(1)
+        writer_started.set()
+        projected.append(_project(store, agent["id"], 2, message_time=now + 1))
+        release.set()
+
+    thread = threading.Thread(target=writer)
+    thread.start()
+    response = store.recovery(agent["id"])
+    thread.join(2)
+    assert not thread.is_alive() and projected
+    assert response["agent"]["revision"] == 1
+    assert response["changes"]["as_of_snapshot_id"] == before_snapshot["id"]
+    assert projected[0]["id"] not in json.dumps(response)
+    assert store.recovery(agent["id"])["agent"]["revision"] == 2
+
+
+def test_recovery_get_does_not_advance_any_baseline_or_write_state(tmp_path):
+    store = AgentStore(str(tmp_path / "agents.sqlite3"))
+    agent = _agent(store)
+    snapshot = _project(store, agent["id"], 1, message_time=time.time())
+    store.visit(agent["id"], snapshot["id"])
+    store.review(agent["id"], snapshot["id"])
+    before = {
+        "changes": store.conn.total_changes,
+        "visit": dict(store.conn.execute(
+            "SELECT * FROM session_visits WHERE session_id=?", (agent["id"],)
+        ).fetchone()),
+        "review": dict(store.conn.execute(
+            "SELECT * FROM session_reviews WHERE session_id=?", (agent["id"],)
+        ).fetchone()),
+        "context": dict(store.conn.execute(
+            "SELECT * FROM agent_contexts WHERE session_id=?", (agent["id"],)
+        ).fetchone()),
+    }
+    response = store.recovery(agent["id"])
+    assert response["changes"]["basis"] == "shared_review"
+    assert store.conn.total_changes == before["changes"]
+    assert dict(store.conn.execute(
+        "SELECT * FROM session_visits WHERE session_id=?", (agent["id"],)
+    ).fetchone()) == before["visit"]
+    assert dict(store.conn.execute(
+        "SELECT * FROM session_reviews WHERE session_id=?", (agent["id"],)
+    ).fetchone()) == before["review"]
+    assert dict(store.conn.execute(
+        "SELECT * FROM agent_contexts WHERE session_id=?", (agent["id"],)
+    ).fetchone()) == before["context"]
+
+
+def test_recovery_reports_message_and_semantic_gaps_independently(tmp_path):
+    store = AgentStore(str(tmp_path / "agents.sqlite3"), retention_days=1)
+    agent = _agent(store)
+    old_secret = "EXPIRED_VISIBLE_SECRET"
+    store.apply_projection(
+        agent["id"],
+        agent["context"],
+        [{
+            "native_event_id": "expired",
+            "role": "assistant",
+            "content": old_secret,
+            "status": "observed",
+            "created_at": time.time() - 2 * 86400,
+        }],
+        [],
+        [],
+    )
+    first = _project(store, agent["id"], 1, message_time=time.time())
+    second = _project(store, agent["id"], 2, message_time=time.time() + 1)
+    initial = store.recovery(agent["id"])
+    assert initial["recent_messages"]["coverage"]["history_truncated"] is True
+    assert initial["recent_timeline"]["coverage"]["history_truncated"] is False
+    assert old_secret not in json.dumps(initial)
+
+    with store.transaction() as conn:
+        conn.execute("DELETE FROM agent_snapshots WHERE id=?", (first["id"],))
+    limited = store.recovery(agent["id"])
+    assert limited["recent_timeline"]["coverage"] == {
+        "retained_from": pytest.approx(second["created_at"]),
+        "retained_to": pytest.approx(second["created_at"]),
+        "history_truncated": True,
+        "unavailable_reason": "expired_or_deleted",
+        "more_retained_older": False,
+        "more_retained_newer": False,
+    }
+    assert limited["recent_messages"]["coverage"]["unavailable_reason"] == "expired_or_deleted"
+
+
+def test_observer_to_recovery_excludes_hidden_tool_terminal_and_path_data(tmp_path):
+    from vmux.agents.models import PaneObservation
+    from vmux.agents.service import AgentService
+    from vmux.config import Config
+
+    cwd = tmp_path / "PRIVATE_CWD_CANARY"
+    cwd.mkdir()
+    log = tmp_path / "codex" / "sessions" / "recovery.jsonl"
+    log.parent.mkdir(parents=True)
+    now = time.time()
+    records = [
+        {
+            "timestamp": now,
+            "type": "session_meta",
+            "payload": {"id": "native-recovery", "cwd": str(cwd)},
+        },
+        {
+            "timestamp": now + 1,
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "Visible recovery request"},
+        },
+        {
+            "timestamp": now + 2,
+            "type": "response_item",
+            "payload": {"type": "reasoning", "summary": "HIDDEN_REASONING_CANARY"},
+        },
+        {
+            "timestamp": now + 3,
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "shell",
+                "arguments": "TOOL_ARGUMENT_CANARY --token SECRET_VALUE_CANARY",
+            },
+        },
+        {
+            "timestamp": now + 4,
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "ordinary-tool",
+                "output": "TOOL_RESULT_CANARY",
+            },
+        },
+        {
+            "timestamp": now + 5,
+            "type": "event_msg",
+            "payload": {"type": "agent_message", "message": "Visible recovery answer"},
+        },
+    ]
+    log.write_text("".join(json.dumps(record) + "\n" for record in records))
+    cfg = Config(
+        experimental_agent_workspace_enabled=True,
+        agent_store_path=str(tmp_path / "agents.sqlite3"),
+        agent_codex_home=str(tmp_path / "codex"),
+        agent_claude_home=str(tmp_path / "claude"),
+    )
+    service = AgentService(cfg)
+    observation = PaneObservation(
+        pane_id="%7",
+        target="work:1.0",
+        command="codex",
+        title="TERMINAL_CAPTURE_CANARY",
+        cwd=str(cwd),
+        pid="7",
+        pane_created=now - 1,
+        runtime="codex",
+        status="idle",
+        question=None,
+        menu=(),
+        prompt_fingerprint="TERMINAL_PROMPT_CANARY",
+        observed_at=now + 6,
+    )
+    asyncio.run(service.process_now([observation]))
+    agent = service.list_agents()[0][0]
+    encoded = json.dumps(service.recovery(agent["id"]), sort_keys=True)
+    assert "Visible recovery request" in encoded
+    assert "Visible recovery answer" in encoded
+    for prohibited in (
+        "PRIVATE_CWD_CANARY",
+        "HIDDEN_REASONING_CANARY",
+        "TOOL_ARGUMENT_CANARY",
+        "TOOL_RESULT_CANARY",
+        "SECRET_VALUE_CANARY",
+        "TERMINAL_CAPTURE_CANARY",
+        "TERMINAL_PROMPT_CANARY",
+    ):
+        assert prohibited not in encoded
+
+
+def test_deleted_cursor_never_projects_future_history_and_private_metadata_is_absent(tmp_path):
+    store = AgentStore(str(tmp_path / "agents.sqlite3"))
+    agent = _agent(store)
+    now = time.time()
+    for index in range(1, 4):
+        _project(store, agent["id"], index, message_time=now + index)
+    first = store.recovery(agent["id"], activity_limit=1)["recent_activity"]
+    cursor = first["older_cursor"]
+    assert cursor
+    assert store.delete_history(agent["id"]) is True
+    _project(store, agent["id"], 9, message_time=now - 1000)
+
+    stale = store.recovery(
+        agent["id"], activity_limit=50, activity_cursor=cursor
+    )["recent_activity"]
+    assert stale["cursor_status"] in ("data_unavailable", "exhausted")
+    assert all("step-9" not in json.dumps(entry) for entry in stale["entries"])
+    encoded = json.dumps(store.recovery(agent["id"]), sort_keys=True)
+    assert "SECRET-log" not in encoded
+    assert "SECRET-cwd" not in encoded
+    assert "runtime_owned_unverified" in encoded
+
+
+def test_recovery_api_is_authenticated_advertised_no_store_and_clamps_limits(tmp_path):
+    from fastapi.testclient import TestClient
+
+    from vmux.config import Config
+    from vmux.server import create_app
+
+    cfg = Config(
+        experimental_agent_workspace_enabled=True,
+        agent_store_path=str(tmp_path / "api-agents.sqlite3"),
+        agent_codex_home=str(tmp_path / "codex"),
+        agent_claude_home=str(tmp_path / "claude"),
+    )
+    cfg.token = "secret"
+    cfg.server_instance_id = "server-fixture"
+    app = create_app(cfg)
+    agent = _agent(app.state.hub.agents.store, native="api")
+    _project(app.state.hub.agents.store, agent["id"], 1, message_time=time.time())
+    with TestClient(app) as client:
+        unauthorized = client.get("/api/agents/%s/recovery" % agent["id"])
+        assert unauthorized.status_code == 401
+        assert unauthorized.headers["cache-control"] == "no-store, max-age=0"
+        auth = {"Authorization": "Bearer secret"}
+        capability = client.get("/api/config", headers=auth).json()["_info"][
+            "capabilities"
+        ]["agent_context_v1"]["recovery"]
+        assert capability == {
+            "version": 1,
+            "path_template": "/api/agents/{id}/recovery",
+            "default_recent_messages": 20,
+            "default_recent_timeline": 20,
+            "default_recent_activity": 20,
+            "max_recent_messages": 50,
+            "max_recent_timeline": 50,
+            "max_recent_activity": 50,
+            "activity_order": "oldest_to_newest",
+        }
+        response = client.get(
+            "/api/agents/%s/recovery" % agent["id"],
+            headers=auth,
+            params={
+                "message_limit": 100000,
+                "timeline_limit": -1,
+                "activity_limit": 100000,
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "no-store, max-age=0"
+        assert response.json()["server_instance_id"] == "server-fixture"
+        for path in (
+            "/api/agents",
+            "/api/agents/%s" % agent["id"],
+            "/api/agents/%s/resume" % agent["id"],
+            "/api/agents/%s/messages" % agent["id"],
+            "/api/agents/%s/timeline" % agent["id"],
+            "/api/timeline",
+            "/api/review",
+            "/api/decisions",
+        ):
+            structured = client.get(path, headers=auth)
+            assert structured.status_code == 200
+            assert structured.headers["cache-control"] == "no-store, max-age=0"
+        missing = client.get("/api/agents/missing/recovery", headers=auth)
+        assert missing.status_code == 404
+        assert missing.headers["cache-control"] == "no-store, max-age=0"
+        malformed = client.get(
+            "/api/agents/%s/recovery" % agent["id"],
+            headers=auth,
+            params={"activity_cursor": "bad"},
+        )
+        assert malformed.status_code == 400
+        assert malformed.headers["cache-control"] == "no-store, max-age=0"
+
+
+def test_canonical_recovery_fixture_tracks_the_discriminated_contract():
+    from pathlib import Path
+
+    fixture = json.loads(
+        (Path(__file__).parents[1] / "docs/reference/recovery-v1.fixture.json").read_text()
+    )
+    assert set(fixture) == {
+        "version",
+        "generated_at",
+        "server_instance_id",
+        "consistency",
+        "agent",
+        "changes",
+        "recent_messages",
+        "recent_timeline",
+        "recent_activity",
+        "freshness",
+    }
+    assert fixture["recent_activity"]["order"] == "oldest_to_newest"
+    assert {entry["kind"] for entry in fixture["recent_activity"]["entries"]} == {
+        "visible_message",
+        "semantic_event",
+    }
+    assert fixture["freshness"]["model_context"] == "runtime_owned_unverified"
+
+
+def test_disabled_capability_omits_recovery_metadata_and_api_is_unavailable(tmp_path):
+    from fastapi.testclient import TestClient
+
+    from vmux.agents.service import AgentService
+    from vmux.config import Config
+    from vmux.server import create_app
+
+    cfg = Config(
+        experimental_agent_workspace_enabled=False,
+        agent_store_path=str(tmp_path / "disabled.sqlite3"),
+    )
+    cfg.token = "secret"
+    assert "recovery" not in AgentService(cfg).info()
+    with TestClient(create_app(cfg)) as client:
+        auth = {"Authorization": "Bearer secret"}
+        capability = client.get("/api/config", headers=auth).json()["_info"][
+            "capabilities"
+        ]["agent_context_v1"]
+        assert "recovery" not in capability
+        response = client.get("/api/agents/anything/recovery", headers=auth)
+        assert response.status_code == 503
+        assert response.json()["detail"] == "agent context is disabled"
+        assert response.headers["cache-control"] == "no-store, max-age=0"
+
+
+def test_recovery_empty_missing_and_cursor_validation(tmp_path):
+    store = AgentStore(str(tmp_path / "agents.sqlite3"))
+    agent = _agent(store)
+    empty = store.recovery(
+        agent["id"], message_limit=0, timeline_limit=-100, activity_limit=0
+    )
+    assert empty["recent_activity"]["entries"] == []
+    assert empty["recent_messages"]["messages"] == []
+    assert empty["recent_timeline"]["events"] == []
+    assert store.recovery("missing") is None
+    for cursor in ("not-opaque", "rc1.a", "rc1.____"):
+        with pytest.raises(ValueError, match="bad recovery cursor"):
+            store.recovery(agent["id"], activity_cursor=cursor)

--- a/vmux/agents/service.py
+++ b/vmux/agents/service.py
@@ -93,7 +93,8 @@ class AgentService:
         self.push = push
         self.kick = kick or (lambda: None)
         self._latest: Dict[str, PaneObservation] = {}
-        self._verified_observations: Dict[str, PaneObservation] = {}
+        self._observation_generation = 0
+        self._verified_observations: Dict[str, Tuple[int, PaneObservation]] = {}
         self._latest_lock = threading.RLock()
         self._process_lock = threading.Lock()
         self._api_lock = threading.RLock()
@@ -231,6 +232,7 @@ class AgentService:
         self._loop = None
         with self._latest_lock:
             self._latest = {}
+            self._observation_generation += 1
             self._verified_observations = {}
         await asyncio.to_thread(self._close_store)
 
@@ -243,6 +245,7 @@ class AgentService:
             return
         with self._latest_lock:
             self._latest = {obs.pane_id: obs for obs in observations}
+            self._observation_generation += 1
             self._verified_observations = {}
         if self._queue is None:
             return
@@ -270,6 +273,7 @@ class AgentService:
             return
         with self._latest_lock:
             self._latest = {obs.pane_id: obs for obs in observations}
+            self._observation_generation += 1
             self._verified_observations = {}
         # Drop an older queued batch before yielding to the worker. If the
         # worker already owns one, _process_lock orders this current batch
@@ -396,7 +400,10 @@ class AgentService:
                 if bound_obs:
                     with self._latest_lock:
                         if self._latest.get(bound_obs.pane_id) == bound_obs:
-                            self._verified_observations[agent["id"]] = bound_obs
+                            self._verified_observations[agent["id"]] = (
+                                self._observation_generation,
+                                bound_obs,
+                            )
 
         agents, cursor = self.store.list_agents(limit=100)
         while True:
@@ -642,7 +649,8 @@ class AgentService:
 
     def recovery(self, session_id: str, **kwargs):
         with self._latest_lock:
-            observation = self._verified_observations.get(session_id)
+            verified_observation = self._verified_observations.get(session_id)
+            observation = verified_observation[1] if verified_observation else None
             runtime_observation = (
                 {
                     "incarnation": observation.incarnation,
@@ -656,6 +664,10 @@ class AgentService:
         )
         if not value:
             raise AgentNotFound(session_id)
+        with self._latest_lock:
+            if self._verified_observations.get(session_id) != verified_observation:
+                value["freshness"]["observed_at"] = None
+                value["freshness"]["runtime_session"] = "unknown"
         return value
 
     def visit(self, session_id: str, snapshot_id: str):

--- a/vmux/agents/service.py
+++ b/vmux/agents/service.py
@@ -93,6 +93,7 @@ class AgentService:
         self.push = push
         self.kick = kick or (lambda: None)
         self._latest: Dict[str, PaneObservation] = {}
+        self._verified_observations: Dict[str, PaneObservation] = {}
         self._latest_lock = threading.RLock()
         self._process_lock = threading.Lock()
         self._api_lock = threading.RLock()
@@ -230,6 +231,7 @@ class AgentService:
         self._loop = None
         with self._latest_lock:
             self._latest = {}
+            self._verified_observations = {}
         await asyncio.to_thread(self._close_store)
 
     async def aclose(self) -> None:
@@ -241,6 +243,7 @@ class AgentService:
             return
         with self._latest_lock:
             self._latest = {obs.pane_id: obs for obs in observations}
+            self._verified_observations = {}
         if self._queue is None:
             return
         now = time.monotonic()
@@ -267,6 +270,7 @@ class AgentService:
             return
         with self._latest_lock:
             self._latest = {obs.pane_id: obs for obs in observations}
+            self._verified_observations = {}
         # Drop an older queued batch before yielding to the worker. If the
         # worker already owns one, _process_lock orders this current batch
         # after it; a stale queued batch can therefore never run afterward.
@@ -389,6 +393,10 @@ class AgentService:
                         source="manual" if manual_obs else "automatic", capabilities=capabilities,
                     )
                 self._ingest_candidate(observer, candidate, agent, bound_obs, capabilities)
+                if bound_obs:
+                    with self._latest_lock:
+                        if self._latest.get(bound_obs.pane_id) == bound_obs:
+                            self._verified_observations[agent["id"]] = bound_obs
 
         agents, cursor = self.store.list_agents(limit=100)
         while True:
@@ -634,15 +642,17 @@ class AgentService:
 
     def recovery(self, session_id: str, **kwargs):
         with self._latest_lock:
-            runtime_observations = {
-                pane_id: {
+            observation = self._verified_observations.get(session_id)
+            runtime_observation = (
+                {
                     "incarnation": observation.incarnation,
                     "observed_at": observation.observed_at,
                 }
-                for pane_id, observation in self._latest.items()
-            }
+                if observation
+                else None
+            )
         value = self.store.recovery(
-            session_id, runtime_observations=runtime_observations, **kwargs
+            session_id, runtime_observation=runtime_observation, **kwargs
         )
         if not value:
             raise AgentNotFound(session_id)

--- a/vmux/agents/service.py
+++ b/vmux/agents/service.py
@@ -578,6 +578,15 @@ class AgentService:
         with self._latest_lock:
             return self._latest.get(pane_id)
 
+    def _observation_is_fresh(
+        self, observation: Optional[PaneObservation]
+    ) -> bool:
+        return bool(
+            observation
+            and time.time() - observation.observed_at
+            <= max(10.0, self.cfg.poll_interval * 4)
+        )
+
     def _validate_live(self, agent: Dict[str, Any], expected_binding_revision: int,
                        *, require_idle: bool, prompt_fingerprint: Optional[str] = None) -> PaneObservation:
         if int(agent["binding_revision"]) != int(expected_binding_revision):
@@ -585,8 +594,9 @@ class AgentService:
         if agent.get("association") != "confirmed" or not agent.get("pane_id"):
             raise AgentUnavailable("agent session is read-only until its pane binding is confirmed")
         obs = self._latest_observation(agent["pane_id"])
-        if not obs or time.time() - obs.observed_at > max(10.0, self.cfg.poll_interval * 4):
+        if not self._observation_is_fresh(obs):
             raise AgentConflict("pane observation is stale", self.store.get_agent(agent["id"]))
+        assert obs is not None
         if require_idle and obs.status != "idle":
             raise AgentConflict("agent is not at an idle prompt", self.store.get_agent(agent["id"]))
         panes = tmux.list_panes()
@@ -651,6 +661,8 @@ class AgentService:
         with self._latest_lock:
             verified_observation = self._verified_observations.get(session_id)
             observation = verified_observation[1] if verified_observation else None
+            if not self._observation_is_fresh(observation):
+                observation = None
             runtime_observation = (
                 {
                     "incarnation": observation.incarnation,
@@ -665,7 +677,10 @@ class AgentService:
         if not value:
             raise AgentNotFound(session_id)
         with self._latest_lock:
-            if self._verified_observations.get(session_id) != verified_observation:
+            if (
+                self._verified_observations.get(session_id) != verified_observation
+                or not self._observation_is_fresh(observation)
+            ):
                 value["freshness"]["observed_at"] = None
                 value["freshness"]["runtime_session"] = "unknown"
         return value
@@ -733,10 +748,8 @@ class AgentService:
             return False
         observation = self._latest_observation(pane_id)
         if (
-            observation is None
+            not self._observation_is_fresh(observation)
             or observation.status != "needs_input"
-            or time.time() - observation.observed_at
-            > max(10.0, self.cfg.poll_interval * 4)
         ):
             return False
         for public_decision in group.get("decisions", []):

--- a/vmux/agents/service.py
+++ b/vmux/agents/service.py
@@ -130,7 +130,7 @@ class AgentService:
 
     def info(self) -> Dict[str, Any]:
         enabled = self.runtime_active
-        return {
+        value = {
             "enabled": enabled,
             "runtimes": ["codex", "claude"],
             "websocket": enabled,
@@ -142,6 +142,19 @@ class AgentService:
             "decisions": "verified_structured_only",
             "degraded_reason": self._disabled_reason,
         }
+        if enabled:
+            value["recovery"] = {
+                "version": 1,
+                "path_template": "/api/agents/{id}/recovery",
+                "default_recent_messages": 20,
+                "default_recent_timeline": 20,
+                "default_recent_activity": 20,
+                "max_recent_messages": 50,
+                "max_recent_timeline": 50,
+                "max_recent_activity": 50,
+                "activity_order": "oldest_to_newest",
+            }
+        return value
 
     def review_info(self) -> Dict[str, Any]:
         enabled = self.runtime_active
@@ -617,6 +630,12 @@ class AgentService:
         if not value:
             raise AgentNotFound(session_id)
         value["agent"] = self._decorate_agent(value["agent"])
+        return value
+
+    def recovery(self, session_id: str, **kwargs):
+        value = self.store.recovery(session_id, **kwargs)
+        if not value:
+            raise AgentNotFound(session_id)
         return value
 
     def visit(self, session_id: str, snapshot_id: str):

--- a/vmux/agents/service.py
+++ b/vmux/agents/service.py
@@ -633,7 +633,17 @@ class AgentService:
         return value
 
     def recovery(self, session_id: str, **kwargs):
-        value = self.store.recovery(session_id, **kwargs)
+        with self._latest_lock:
+            runtime_observations = {
+                pane_id: {
+                    "incarnation": observation.incarnation,
+                    "observed_at": observation.observed_at,
+                }
+                for pane_id, observation in self._latest.items()
+            }
+        value = self.store.recovery(
+            session_id, runtime_observations=runtime_observations, **kwargs
+        )
         if not value:
             raise AgentNotFound(session_id)
         return value

--- a/vmux/agents/store.py
+++ b/vmux/agents/store.py
@@ -1245,7 +1245,11 @@ class AgentStore:
         }
 
     @staticmethod
-    def _runtime_session_state(agent: Dict[str, Any]) -> str:
+    def _runtime_session_state(
+        agent: Dict[str, Any], observation: Optional[Dict[str, Any]]
+    ) -> str:
+        if observation is None:
+            return "unknown"
         lifecycle = str(agent.get("lifecycle") or agent.get("context", {}).get("lifecycle") or "")
         association = str(agent.get("association") or "")
         if association == "confirmed" and lifecycle not in ("offline", "completed"):
@@ -1266,6 +1270,7 @@ class AgentStore:
         message_cursor: Optional[str] = None,
         timeline_cursor: Optional[str] = None,
         activity_cursor: Optional[str] = None,
+        runtime_observations: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> Optional[Dict[str, Any]]:
         """Return one bounded, non-mutating SQLite view of recovery state."""
         with self.read_transaction() as conn:
@@ -1274,9 +1279,16 @@ class AgentStore:
             if not agent:
                 return None
             context_row = conn.execute(
-                "SELECT revision,updated_at FROM agent_contexts WHERE session_id=?",
+                """SELECT c.revision,c.updated_at,s.pane_incarnation
+                   FROM agent_contexts c JOIN agent_sessions s ON s.id=c.session_id
+                   WHERE c.session_id=?""",
                 (session_id,),
             ).fetchone()
+            observation = None
+            if agent.get("pane_id") and runtime_observations:
+                candidate = runtime_observations.get(str(agent["pane_id"]))
+                if candidate and candidate.get("incarnation") == context_row["pane_incarnation"]:
+                    observation = candidate
             anchors = conn.execute(
                 """SELECT
                        COALESCE((SELECT MAX(rowid) FROM chat_messages WHERE session_id=?),0)
@@ -1476,10 +1488,10 @@ class AgentStore:
                     },
                 },
                 "freshness": {
-                    "observed_at": generated_at,
+                    "observed_at": observation.get("observed_at") if observation else None,
                     "projected_at": context_row["updated_at"],
                     "last_runtime_event_at": agent.get("last_event_at"),
-                    "runtime_session": self._runtime_session_state(agent),
+                    "runtime_session": self._runtime_session_state(agent, observation),
                     "model_context": "runtime_owned_unverified",
                 },
             }

--- a/vmux/agents/store.py
+++ b/vmux/agents/store.py
@@ -991,7 +991,6 @@ class AgentStore:
         next_cursor = str(offset + limit) if len(rows) > limit else None
         if not with_metadata:
             return values, next_cursor
-        cutoff = time.time() - self.retention_days * 86400
         metadata = {
             "retained_from": bounds["retained_from"] if bounds else None,
             "retained_to": bounds["retained_to"] if bounds else None,
@@ -1011,12 +1010,9 @@ class AgentStore:
             "reviewed_at": session["reviewed_at"] if session else None,
             "history_truncated": bool(
                 session
-                and (
-                    float(session["created_at"]) < cutoff
-                    or bool(
-                        self._loads(session["context_json"], {}).get(
-                            "message_history_truncated"
-                        )
+                and bool(
+                    self._loads(session["context_json"], {}).get(
+                        "message_history_truncated"
                     )
                 )
             ),
@@ -1270,7 +1266,7 @@ class AgentStore:
         message_cursor: Optional[str] = None,
         timeline_cursor: Optional[str] = None,
         activity_cursor: Optional[str] = None,
-        runtime_observations: Optional[Dict[str, Dict[str, Any]]] = None,
+        runtime_observation: Optional[Dict[str, Any]] = None,
     ) -> Optional[Dict[str, Any]]:
         """Return one bounded, non-mutating SQLite view of recovery state."""
         with self.read_transaction() as conn:
@@ -1285,10 +1281,13 @@ class AgentStore:
                 (session_id,),
             ).fetchone()
             observation = None
-            if agent.get("pane_id") and runtime_observations:
-                candidate = runtime_observations.get(str(agent["pane_id"]))
-                if candidate and candidate.get("incarnation") == context_row["pane_incarnation"]:
-                    observation = candidate
+            if (
+                agent.get("pane_id")
+                and runtime_observation
+                and runtime_observation.get("incarnation")
+                == context_row["pane_incarnation"]
+            ):
+                observation = runtime_observation
             anchors = conn.execute(
                 """SELECT
                        COALESCE((SELECT MAX(rowid) FROM chat_messages WHERE session_id=?),0)
@@ -1412,10 +1411,8 @@ class AgentStore:
                    FROM chat_messages WHERE session_id=?""",
                 (session_id,),
             ).fetchone()
-            cutoff = generated_at - self.retention_days * 86400
             message_history_truncated = bool(
-                float(agent["created_at"]) < cutoff
-                or agent["context"].get("message_history_truncated")
+                agent["context"].get("message_history_truncated")
             )
             timeline_bounds = {
                 "retained_from": oldest["created_at"] if oldest else None,

--- a/vmux/agents/store.py
+++ b/vmux/agents/store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import hashlib
 import json
 import math
@@ -18,6 +20,8 @@ from .models import default_capabilities, empty_context, semantic_delta
 SCHEMA_VERSION = 2
 MIN_REVIEW_INTERVAL_MINUTES = 5
 MAX_REVIEW_INTERVAL_MINUTES = 1440
+MAX_RECOVERY_ITEMS = 50
+RECOVERY_CURSOR_VERSION = 1
 
 
 class AgentStore:
@@ -86,6 +90,22 @@ class AgentStore:
             conn = self.conn
             try:
                 conn.execute("BEGIN IMMEDIATE")
+                yield conn
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+
+    @contextmanager
+    def read_transaction(self):
+        """Hold one SQLite snapshot without acquiring a write reservation."""
+        with self._lock:
+            conn = self.conn
+            try:
+                conn.execute("BEGIN")
+                # Establish the snapshot before any response timestamp or
+                # section query can observe a later projection.
+                conn.execute("SELECT 1 FROM schema_migrations LIMIT 1").fetchone()
                 yield conn
                 conn.commit()
             except Exception:
@@ -314,6 +334,97 @@ class AgentStore:
         if result < 0:
             raise ValueError("bad cursor")
         return result
+
+    @classmethod
+    def _encode_recovery_cursor(
+        cls,
+        *,
+        kind: str,
+        session_id: str,
+        anchor_at: float,
+        message_anchor: int,
+        snapshot_anchor: int,
+        direction: str,
+        boundary: Tuple[float, int, int, str],
+    ) -> str:
+        payload = {
+            "v": RECOVERY_CURSOR_VERSION,
+            "k": kind,
+            "s": session_id,
+            "a": anchor_at,
+            "m": message_anchor,
+            "p": snapshot_anchor,
+            "d": direction,
+            "b": list(boundary),
+        }
+        raw = cls._canonical_dumps(payload).encode("utf-8")
+        # The checksum catches accidental corruption. Cursors confer no extra
+        # authority: authentication and the session id are still enforced.
+        checksum = hashlib.sha256(b"vmux-recovery-v1\0" + raw).digest()[:12]
+        token = base64.urlsafe_b64encode(checksum + raw).decode("ascii").rstrip("=")
+        return "rc1." + token
+
+    @classmethod
+    def _decode_recovery_cursor(
+        cls, value: Optional[str], *, kind: str, session_id: str
+    ) -> Optional[Dict[str, Any]]:
+        if value in (None, ""):
+            return None
+        text = str(value)
+        if not text.startswith("rc1.") or len(text) > 1000:
+            raise ValueError("bad recovery cursor")
+        encoded = text[4:]
+        try:
+            decoded = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+            checksum, raw = decoded[:12], decoded[12:]
+            if len(checksum) != 12 or not hashlib.sha256(
+                b"vmux-recovery-v1\0" + raw
+            ).digest()[:12] == checksum:
+                raise ValueError
+            payload = json.loads(raw)
+            boundary = payload.get("b")
+            if (
+                payload.get("v") != RECOVERY_CURSOR_VERSION
+                or payload.get("k") != kind
+                or payload.get("s") != session_id
+                or payload.get("d") not in ("older", "newer")
+                or not isinstance(boundary, list)
+                or len(boundary) != 4
+            ):
+                raise ValueError
+            anchor_at = float(payload["a"])
+            message_anchor = int(payload["m"])
+            snapshot_anchor = int(payload["p"])
+            normalized_boundary = (
+                float(boundary[0]), int(boundary[1]), int(boundary[2]), str(boundary[3])
+            )
+            if (
+                not math.isfinite(anchor_at)
+                or not math.isfinite(normalized_boundary[0])
+                or not 0 <= message_anchor <= 2**63 - 1
+                or not 0 <= snapshot_anchor <= 2**63 - 1
+                or normalized_boundary[1] not in (0, 1)
+                or not 0 <= normalized_boundary[2] <= 2**63 - 1
+                or not normalized_boundary[3]
+                or len(normalized_boundary[3]) > 160
+            ):
+                raise ValueError
+        except (
+            binascii.Error,
+            json.JSONDecodeError,
+            KeyError,
+            TypeError,
+            UnicodeDecodeError,
+            ValueError,
+        ):
+            raise ValueError("bad recovery cursor")
+        return {
+            "anchor_at": anchor_at,
+            "message_anchor": message_anchor,
+            "snapshot_anchor": snapshot_anchor,
+            "direction": payload["d"],
+            "boundary": normalized_boundary,
+        }
 
     def upsert_session(self, runtime: str, native_session_id: str, source_path: str,
                        source_cwd: str, parser_version: str) -> Dict[str, Any]:
@@ -918,6 +1029,39 @@ class AgentStore:
         }
         return values, next_cursor, metadata
 
+    @classmethod
+    def _public_timeline_event(
+        cls, row: sqlite3.Row, *, include_context: bool = True
+    ) -> Dict[str, Any]:
+        event = {
+            "id": row["id"],
+            "agent_id": row["session_id"],
+            "sequence": row["sequence"],
+            "created_at": row["created_at"],
+            "occurred_at": row["created_at"],
+            "delta": cls._loads(row["delta_json"], {}),
+            "context": cls._loads(row["context_json"], {}) if include_context else None,
+        }
+        delta = event["delta"]
+        lifecycle = delta.get("lifecycle_changed", {}).get("to")
+        if lifecycle == "waiting":
+            event.update({"type": "decision", "title": "Agent is waiting for a decision"})
+        elif lifecycle == "completed":
+            event.update({"type": "completed", "title": "Agent completed its work"})
+        elif delta.get("new_blockers"):
+            event.update({"type": "blocker", "title": "A new blocker was reported"})
+        elif delta.get("completed"):
+            count = len(delta["completed"])
+            event.update({
+                "type": "progress",
+                "title": "%d item%s completed" % (count, "" if count == 1 else "s"),
+            })
+        elif delta.get("goal_changed") or delta.get("current_task_changed"):
+            event.update({"type": "context", "title": "Agent context changed"})
+        else:
+            event.update({"type": "activity", "title": "Agent activity updated"})
+        return event
+
     def timeline(self, session_id: Optional[str], cursor: Optional[str] = None, limit: int = 50):
         offset = self._cursor(cursor)
         limit = max(1, min(100, int(limit)))
@@ -933,29 +1077,412 @@ class AgentStore:
                     "SELECT * FROM agent_snapshots ORDER BY created_at DESC,id LIMIT ? OFFSET ?",
                     (limit + 1, offset),
                 ).fetchall()
-        events = [{
-            "id": row["id"], "agent_id": row["session_id"], "sequence": row["sequence"],
-            "created_at": row["created_at"], "occurred_at": row["created_at"],
-            "delta": self._loads(row["delta_json"], {}),
-            "context": self._loads(row["context_json"], {}) if session_id else None,
-        } for row in rows[:limit]]
-        for event in events:
-            delta = event["delta"]
-            lifecycle = delta.get("lifecycle_changed", {}).get("to")
-            if lifecycle == "waiting":
-                event.update({"type": "decision", "title": "Agent is waiting for a decision"})
-            elif lifecycle == "completed":
-                event.update({"type": "completed", "title": "Agent completed its work"})
-            elif delta.get("new_blockers"):
-                event.update({"type": "blocker", "title": "A new blocker was reported"})
-            elif delta.get("completed"):
-                count = len(delta["completed"])
-                event.update({"type": "progress", "title": "%d item%s completed" % (count, "" if count == 1 else "s")})
-            elif delta.get("goal_changed") or delta.get("current_task_changed"):
-                event.update({"type": "context", "title": "Agent context changed"})
-            else:
-                event.update({"type": "activity", "title": "Agent activity updated"})
+        events = [
+            self._public_timeline_event(row, include_context=bool(session_id))
+            for row in rows[:limit]
+        ]
         return events, str(offset + limit) if len(rows) > limit else None
+
+    @staticmethod
+    def _recovery_order_predicate(
+        relation: str, boundary: Tuple[float, int, int, str]
+    ) -> Tuple[str, Tuple[Any, ...]]:
+        if relation not in ("<", ">"):
+            raise ValueError("bad recovery cursor direction")
+        occurred_at, kind_rank, source_order, resource_id = boundary
+        sql = (
+            "(occurred_at {r} ? OR (occurred_at=? AND "
+            "(kind_rank {r} ? OR (kind_rank=? AND "
+            "(source_order {r} ? OR (source_order=? AND resource_id {r} ?))))))"
+        ).format(r=relation)
+        return sql, (
+            occurred_at,
+            occurred_at,
+            kind_rank,
+            kind_rank,
+            source_order,
+            source_order,
+            resource_id,
+        )
+
+    def _recovery_page(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        session_id: str,
+        cursor_kind: str,
+        cursor: Optional[str],
+        limit: int,
+        generated_at: float,
+        message_anchor: int,
+        snapshot_anchor: int,
+        only_kind_rank: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        parsed = self._decode_recovery_cursor(
+            cursor, kind=cursor_kind, session_id=session_id
+        )
+        anchor_at = parsed["anchor_at"] if parsed else generated_at
+        message_anchor = parsed["message_anchor"] if parsed else message_anchor
+        snapshot_anchor = parsed["snapshot_anchor"] if parsed else snapshot_anchor
+        direction = parsed["direction"] if parsed else "older"
+        boundary = parsed["boundary"] if parsed else None
+        limit = max(1, min(MAX_RECOVERY_ITEMS, int(limit)))
+
+        cte = """WITH activity AS (
+            SELECT 'visible_message' AS activity_kind,0 AS kind_rank,
+                   m.rowid AS source_order,m.id AS resource_id,
+                   m.created_at AS occurred_at,m.*,
+                   NULL AS sequence,NULL AS delta_json,NULL AS context_json
+            FROM chat_messages m
+            WHERE m.session_id=? AND m.rowid<=? AND m.updated_at<=?
+            UNION ALL
+            SELECT 'semantic_event' AS activity_kind,1 AS kind_rank,
+                   s.sequence AS source_order,s.id AS resource_id,
+                   s.created_at AS occurred_at,
+                   s.id AS id,NULL AS conversation_id,s.session_id,
+                   NULL AS native_event_id,NULL AS client_message_id,
+                   NULL AS role,NULL AS content,NULL AS status,
+                   s.created_at,s.created_at AS updated_at,
+                   s.sequence,s.delta_json,s.context_json
+            FROM agent_snapshots s
+            WHERE s.session_id=? AND s.sequence<=? AND s.created_at<=?
+        )"""
+        cte_args: Tuple[Any, ...] = (
+            session_id,
+            message_anchor,
+            anchor_at,
+            session_id,
+            snapshot_anchor,
+            anchor_at,
+        )
+
+        def where_for(
+            relation: Optional[str], key: Optional[Tuple[float, int, int, str]]
+        ) -> Tuple[str, Tuple[Any, ...]]:
+            clauses: List[str] = []
+            args: Tuple[Any, ...] = ()
+            if only_kind_rank is not None:
+                clauses.append("kind_rank=?")
+                args += (only_kind_rank,)
+            if relation and key:
+                predicate, predicate_args = self._recovery_order_predicate(
+                    relation, key
+                )
+                clauses.append(predicate)
+                args += predicate_args
+            return (" WHERE " + " AND ".join(clauses) if clauses else ""), args
+
+        relation = ">" if direction == "newer" else "<"
+        page_where, page_args = where_for(relation if boundary else None, boundary)
+        sql_order = "ASC" if direction == "newer" else "DESC"
+        rows = conn.execute(
+            cte
+            + " SELECT * FROM activity"
+            + page_where
+            + " ORDER BY occurred_at %s,kind_rank %s,source_order %s,resource_id %s LIMIT ?"
+            % ((sql_order,) * 4),
+            cte_args + page_args + (limit,),
+        ).fetchall()
+        if direction != "newer":
+            rows = list(reversed(rows))
+
+        def key(row: sqlite3.Row) -> Tuple[float, int, int, str]:
+            return (
+                float(row["occurred_at"]),
+                int(row["kind_rank"]),
+                int(row["source_order"]),
+                str(row["resource_id"]),
+            )
+
+        low = key(rows[0]) if rows else boundary
+        high = key(rows[-1]) if rows else boundary
+
+        def exists(relation: str, edge: Optional[Tuple[float, int, int, str]]) -> bool:
+            if edge is None:
+                return False
+            where, args = where_for(relation, edge)
+            return conn.execute(
+                cte + " SELECT 1 FROM activity" + where + " LIMIT 1",
+                cte_args + args,
+            ).fetchone() is not None
+
+        has_older = exists("<", low)
+        has_newer = exists(">", high)
+
+        def encoded(
+            requested_direction: str,
+            edge: Optional[Tuple[float, int, int, str]],
+            available: bool,
+        ) -> Optional[str]:
+            if not available or edge is None:
+                return None
+            return self._encode_recovery_cursor(
+                kind=cursor_kind,
+                session_id=session_id,
+                anchor_at=anchor_at,
+                message_anchor=message_anchor,
+                snapshot_anchor=snapshot_anchor,
+                direction=requested_direction,
+                boundary=edge,
+            )
+
+        if parsed is None:
+            cursor_status = "current"
+        elif rows:
+            cursor_status = "valid"
+        elif has_older or has_newer:
+            cursor_status = "data_unavailable"
+        else:
+            cursor_status = "exhausted"
+        return {
+            "rows": rows,
+            "older_cursor": encoded("older", low, has_older),
+            "newer_cursor": encoded("newer", high, has_newer),
+            "cursor_status": cursor_status,
+            "anchor_at": anchor_at,
+            "message_anchor": message_anchor,
+            "snapshot_anchor": snapshot_anchor,
+        }
+
+    @staticmethod
+    def _runtime_session_state(agent: Dict[str, Any]) -> str:
+        lifecycle = str(agent.get("lifecycle") or agent.get("context", {}).get("lifecycle") or "")
+        association = str(agent.get("association") or "")
+        if association == "confirmed" and lifecycle not in ("offline", "completed"):
+            return "live_bound"
+        if lifecycle in ("offline", "completed") or association == "unavailable":
+            return "offline"
+        if association in ("probable", "ambiguous") and agent.get("last_event_at") is not None:
+            return "observed_unbound"
+        return "unknown"
+
+    def recovery(
+        self,
+        session_id: str,
+        *,
+        message_limit: int = 20,
+        timeline_limit: int = 20,
+        activity_limit: int = 20,
+        message_cursor: Optional[str] = None,
+        timeline_cursor: Optional[str] = None,
+        activity_cursor: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return one bounded, non-mutating SQLite view of recovery state."""
+        with self.read_transaction() as conn:
+            generated_at = time.time()
+            agent = self.get_agent(session_id)
+            if not agent:
+                return None
+            context_row = conn.execute(
+                "SELECT revision,updated_at FROM agent_contexts WHERE session_id=?",
+                (session_id,),
+            ).fetchone()
+            anchors = conn.execute(
+                """SELECT
+                       COALESCE((SELECT MAX(rowid) FROM chat_messages WHERE session_id=?),0)
+                           AS message_anchor,
+                       COALESCE((SELECT MAX(sequence) FROM agent_snapshots WHERE session_id=?),0)
+                           AS snapshot_anchor""",
+                (session_id, session_id),
+            ).fetchone()
+            message_anchor = int(anchors["message_anchor"])
+            snapshot_anchor = int(anchors["snapshot_anchor"])
+
+            newest = conn.execute(
+                "SELECT * FROM agent_snapshots WHERE session_id=? ORDER BY sequence DESC LIMIT 1",
+                (session_id,),
+            ).fetchone()
+            oldest = conn.execute(
+                "SELECT * FROM agent_snapshots WHERE session_id=? ORDER BY sequence LIMIT 1",
+                (session_id,),
+            ).fetchone()
+            review = conn.execute(
+                "SELECT * FROM session_reviews WHERE session_id=?", (session_id,)
+            ).fetchone()
+            visit = conn.execute(
+                "SELECT * FROM session_visits WHERE session_id=?", (session_id,)
+            ).fetchone()
+            baseline_record = review or visit
+            basis = (
+                "shared_review"
+                if review
+                else "legacy_shared_visit"
+                if visit
+                else "available_history"
+            )
+            baseline = None
+            if baseline_record and baseline_record["snapshot_id"]:
+                baseline = conn.execute(
+                    "SELECT * FROM agent_snapshots WHERE id=? AND session_id=?",
+                    (baseline_record["snapshot_id"], session_id),
+                ).fetchone()
+            changes_truncated = bool(
+                baseline_record and baseline_record["snapshot_id"] and baseline is None
+            )
+            baseline_sequence = int(
+                baseline_record["snapshot_sequence"] if baseline_record else 0
+            )
+            if changes_truncated and oldest:
+                baseline = oldest
+            if baseline_record and oldest:
+                changes_truncated = changes_truncated or bool(
+                    baseline_sequence < int(oldest["sequence"]) - 1
+                )
+            semantic_earlier_unavailable = bool(
+                (
+                    oldest
+                    and (
+                        int(oldest["sequence"]) > 1
+                        or int(context_row["revision"])
+                        > int(newest["sequence"] if newest else 0)
+                    )
+                )
+                or (oldest is None and int(context_row["revision"]) > 0)
+            )
+            if not baseline_record:
+                changes_truncated = semantic_earlier_unavailable
+            baseline_context = self._loads(baseline["context_json"], {}) if baseline else {}
+
+            message_page = self._recovery_page(
+                conn,
+                session_id=session_id,
+                cursor_kind="messages",
+                cursor=message_cursor,
+                limit=message_limit,
+                generated_at=generated_at,
+                message_anchor=message_anchor,
+                snapshot_anchor=snapshot_anchor,
+                only_kind_rank=0,
+            )
+            timeline_page = self._recovery_page(
+                conn,
+                session_id=session_id,
+                cursor_kind="timeline",
+                cursor=timeline_cursor,
+                limit=timeline_limit,
+                generated_at=generated_at,
+                message_anchor=message_anchor,
+                snapshot_anchor=snapshot_anchor,
+                only_kind_rank=1,
+            )
+            activity_page = self._recovery_page(
+                conn,
+                session_id=session_id,
+                cursor_kind="activity",
+                cursor=activity_cursor,
+                limit=activity_limit,
+                generated_at=generated_at,
+                message_anchor=message_anchor,
+                snapshot_anchor=snapshot_anchor,
+            )
+
+            message_rows = message_page.pop("rows")
+            timeline_rows = timeline_page.pop("rows")
+            activity_rows = activity_page.pop("rows")
+            messages = [self._public_message(row) for row in message_rows]
+            timeline = [self._public_timeline_event(row) for row in timeline_rows]
+            entries = []
+            for row in activity_rows:
+                if row["activity_kind"] == "visible_message":
+                    resource = self._public_message(row)
+                else:
+                    resource = self._public_timeline_event(row)
+                entries.append({
+                    "id": "%s:%s" % (row["activity_kind"], row["resource_id"]),
+                    "kind": row["activity_kind"],
+                    "occurred_at": row["occurred_at"],
+                    "resource_id": row["resource_id"],
+                    "resource": resource,
+                })
+
+            message_bounds = conn.execute(
+                """SELECT MIN(created_at) AS retained_from,MAX(created_at) AS retained_to
+                   FROM chat_messages WHERE session_id=?""",
+                (session_id,),
+            ).fetchone()
+            cutoff = generated_at - self.retention_days * 86400
+            message_history_truncated = bool(
+                float(agent["created_at"]) < cutoff
+                or agent["context"].get("message_history_truncated")
+            )
+            timeline_bounds = {
+                "retained_from": oldest["created_at"] if oldest else None,
+                "retained_to": newest["created_at"] if newest else None,
+            }
+
+            message_coverage = {
+                "retained_from": message_bounds["retained_from"],
+                "retained_to": message_bounds["retained_to"],
+                "history_truncated": message_history_truncated,
+                "unavailable_reason": (
+                    "expired_or_deleted" if message_history_truncated else None
+                ),
+                "more_retained_older": message_page["older_cursor"] is not None,
+                "more_retained_newer": message_page["newer_cursor"] is not None,
+            }
+            timeline_coverage = {
+                **timeline_bounds,
+                "history_truncated": semantic_earlier_unavailable,
+                "unavailable_reason": (
+                    "expired_or_deleted" if semantic_earlier_unavailable else None
+                ),
+                "more_retained_older": timeline_page["older_cursor"] is not None,
+                "more_retained_newer": timeline_page["newer_cursor"] is not None,
+            }
+            changes = {
+                "basis": basis,
+                "baseline_snapshot_id": (
+                    baseline_record["snapshot_id"] if baseline_record else None
+                ),
+                "as_of_snapshot_id": newest["id"] if newest else None,
+                "history_truncated": changes_truncated,
+                "unavailable_reason": (
+                    "expired_or_deleted" if changes_truncated else None
+                ),
+                "delta": semantic_delta(baseline_context, agent["context"]),
+            }
+            return {
+                "version": 1,
+                "generated_at": generated_at,
+                "consistency": "single_read",
+                "agent": agent,
+                "changes": changes,
+                "recent_messages": {
+                    "order": "oldest_to_newest",
+                    "messages": messages,
+                    "next_cursor": message_page["older_cursor"],
+                    "previous_cursor": message_page["newer_cursor"],
+                    "cursor_status": message_page["cursor_status"],
+                    "coverage": message_coverage,
+                },
+                "recent_timeline": {
+                    "order": "oldest_to_newest",
+                    "events": timeline,
+                    "next_cursor": timeline_page["older_cursor"],
+                    "previous_cursor": timeline_page["newer_cursor"],
+                    "cursor_status": timeline_page["cursor_status"],
+                    "coverage": timeline_coverage,
+                },
+                "recent_activity": {
+                    "order": "oldest_to_newest",
+                    "tie_break": "occurred_at_kind_source_order_resource_id",
+                    "entries": entries,
+                    "older_cursor": activity_page["older_cursor"],
+                    "newer_cursor": activity_page["newer_cursor"],
+                    "cursor_status": activity_page["cursor_status"],
+                    "coverage": {
+                        "visible_messages": message_coverage,
+                        "semantic_history": timeline_coverage,
+                    },
+                },
+                "freshness": {
+                    "observed_at": generated_at,
+                    "projected_at": context_row["updated_at"],
+                    "last_runtime_event_at": agent.get("last_event_at"),
+                    "runtime_session": self._runtime_session_state(agent),
+                    "model_context": "runtime_owned_unverified",
+                },
+            }
 
     def resume(self, session_id: str) -> Optional[Dict[str, Any]]:
         agent = self.get_agent(session_id)

--- a/vmux/agents/store.py
+++ b/vmux/agents/store.py
@@ -1333,8 +1333,6 @@ class AgentStore:
             baseline_sequence = int(
                 baseline_record["snapshot_sequence"] if baseline_record else 0
             )
-            if changes_truncated and oldest:
-                baseline = oldest
             if baseline_record and oldest:
                 changes_truncated = changes_truncated or bool(
                     baseline_sequence < int(oldest["sequence"]) - 1
@@ -1352,7 +1350,15 @@ class AgentStore:
             )
             if not baseline_record:
                 changes_truncated = semantic_earlier_unavailable
-            baseline_context = self._loads(baseline["context_json"], {}) if baseline else {}
+            if changes_truncated and baseline is None:
+                baseline = oldest
+            baseline_context = (
+                self._loads(baseline["context_json"], {})
+                if baseline
+                else agent["context"]
+                if changes_truncated
+                else {}
+            )
 
             message_page = self._recovery_page(
                 conn,

--- a/vmux/poller.py
+++ b/vmux/poller.py
@@ -24,8 +24,8 @@ from .models import (
     KIND_CODEX,
     KIND_GENERIC,
     STATUS_IDLE,
-    STATUS_WORKING,
     STATUS_OFFLINE,
+    STATUS_WORKING,
     PaneState,
 )
 from .naming import SmartNamer

--- a/vmux/server.py
+++ b/vmux/server.py
@@ -197,6 +197,20 @@ def create_app(cfg: Config, *, image_store: Optional[ImageStore] = None) -> Fast
     app.state.images = images
     app.state.creation = creation
 
+    @app.middleware("http")
+    async def prevent_structured_context_caching(request: Request, call_next):
+        response = await call_next(request)
+        path = request.url.path
+        if request.method == "GET" and (
+            path == "/api/review"
+            or path == "/api/timeline"
+            or path == "/api/decisions"
+            or path.startswith("/api/agents")
+            or path.startswith("/api/decisions/")
+        ):
+            response.headers["Cache-Control"] = "no-store, max-age=0"
+        return response
+
     def require_auth(authorization: Optional[str] = Header(None)):
         if not cfg.token:
             return
@@ -470,6 +484,30 @@ def create_app(cfg: Config, *, image_store: Optional[ImageStore] = None) -> Fast
     @app.get("/api/agents/{agent_id}/resume")
     def get_agent_resume(agent_id: str, _=Depends(require_auth)):
         return _agent_call(hub.agents.resume, agent_id)
+
+    @app.get("/api/agents/{agent_id}/recovery")
+    def get_agent_recovery(
+        agent_id: str,
+        message_limit: int = 20,
+        timeline_limit: int = 20,
+        activity_limit: int = 20,
+        message_cursor: Optional[str] = Query(default=None, max_length=1000),
+        timeline_cursor: Optional[str] = Query(default=None, max_length=1000),
+        activity_cursor: Optional[str] = Query(default=None, max_length=1000),
+        _=Depends(require_auth),
+    ):
+        value = _agent_call(
+            hub.agents.recovery,
+            agent_id,
+            message_limit=message_limit,
+            timeline_limit=timeline_limit,
+            activity_limit=activity_limit,
+            message_cursor=message_cursor,
+            timeline_cursor=timeline_cursor,
+            activity_cursor=activity_cursor,
+        )
+        value["server_instance_id"] = cfg.server_instance_id
+        return value
 
     @app.get("/api/review")
     def get_review(_=Depends(require_auth)):

--- a/vmux/server.py
+++ b/vmux/server.py
@@ -491,9 +491,9 @@ def create_app(cfg: Config, *, image_store: Optional[ImageStore] = None) -> Fast
         message_limit: int = 20,
         timeline_limit: int = 20,
         activity_limit: int = 20,
-        message_cursor: Optional[str] = Query(default=None, max_length=1000),
-        timeline_cursor: Optional[str] = Query(default=None, max_length=1000),
-        activity_cursor: Optional[str] = Query(default=None, max_length=1000),
+        message_cursor: Optional[str] = None,
+        timeline_cursor: Optional[str] = None,
+        activity_cursor: Optional[str] = None,
         _=Depends(require_auth),
     ):
         value = _agent_call(


### PR DESCRIPTION
## Intent

Implement the backend foundation for a user-facing session recovery option, using the established recovery-v1 design evidence, so an iOS client can receive a current structured brief plus accurate available changes, recent visible conversation, recent semantic activity, freshness, retention coverage, and a bounded deterministic recent-activity sequence traversable toward older retained data and back toward the present. Add an optional backward-compatible capability advertisement and an authenticated additive GET API that performs one consistent read and never sends chat, resumes execution, binds a pane, observes logs, or advances visit, Review, read, or runtime state. Reuse the existing semantic timeline, visible-message, context, snapshot, retention, and pagination data rather than adding a history store or generated narrative. Clamp limits and make opaque cursor ordering stable and documented across timestamp ties, duplicates, out-of-order source events, long sessions, concurrent projection, deletion/retention, empty and missing sessions, disabled capability, and server restart, while keeping more-retained data distinct from expired/deleted data and visible-message gaps distinct from semantic-history gaps. Never claim runtime/model context was restored: report model state as runtime-owned and unverified. Do not expose hidden reasoning, tool arguments/results, terminal capture, source paths/CWD, secrets, or unbounded history; preserve authentication and existing safety guards; add Cache-Control: no-store, max-age=0 to structured recovery/context GET responses as appropriate. Keep existing clients/endpoints compatible, add behavioral consistency/non-mutation/privacy/API tests, update backend/companion/privacy/cache documentation and capability examples, and provide a canonical JSON fixture for the later iOS consumer. Retain as baseline evidence that test_successful_switch_change_invalidates_other_pwa_config_clients hangs with the same bounded timeout on clean origin/main; do not treat that pre-existing hang as a branch regression. Push only this feature branch, open a product-facing PR, and do not merge it.

## What Changed

- Add an authenticated recovery-v1 endpoint and optional capability advertisement that return a consistent, non-mutating session brief, changes, freshness, and retained activity.
- Add bounded bidirectional cursor traversal with deterministic ordering and separate visible-message and semantic-history coverage.
- Add recovery API regression coverage, a canonical JSON fixture, privacy documentation, and non-cacheable structured context responses.

## Risk Assessment

✅ Low: The recovery API is well-bounded, and the current code resolves the previously selected freshness, retention, cursor-validation, and truncated-baseline issues without introducing another substantiated defect.

## Testing

The supplied clean-origin baseline hang was retained as pre-existing and not rerun; the focused recovery module passed, and an authenticated client-level API exercise demonstrated bounded deterministic round-trip traversal, privacy-safe freshness semantics, no-store caching, and no SQLite mutation. No visual artifact was captured because the change is backend/API-only.

<details>
<summary>Evidence: Recovery API end-to-end evidence</summary>

<code>Authenticated request returned 200 with `single_read`, `no-store, max-age=0`, bounded activity, and `runtime_owned_unverified`. Four-page older/newer traversal returned all 12 unique entries without skips; persisted SQLite state was identical before and after GETs.</code>

```text
{
  "capability_request": {
    "recovery": {
      "activity_order": "oldest_to_newest",
      "default_recent_activity": 20,
      "default_recent_messages": 20,
      "default_recent_timeline": 20,
      "max_recent_activity": 50,
      "max_recent_messages": 50,
      "max_recent_timeline": 50,
      "path_template": "/api/agents/{id}/recovery",
      "version": 1
    },
    "status": 200
  },
  "cursor_traversal": {
    "chronological_entry_ids": [
      "visible_message:dc8a07c9-8fcf-4b45-8bc3-57d0dbef3d83",
      "visible_message:540ab4ff-c8e0-480c-a986-6b4ad65262f1",
      "visible_message:057d1dde-3aa2-4f4b-b18b-3554015f748e",
      "visible_message:779e1473-d402-4303-bb6c-f61db7ac25e4",
      "visible_message:31b655e1-2928-49ee-91dd-07203d5bc6a2",
      "visible_message:d0d929c8-7940-4755-a98c-cda0c74b94c2",
      "semantic_event:6562148c-d2be-45ee-8df3-a8ccdb5a097e",
      "semantic_event:642062ab-48e3-4392-aace-12b2846d4854",
      "semantic_event:62affd6f-914c-459e-9c99-8b8c1d5ecfad",
      "semantic_event:7ea0069c-0dae-4544-a0ee-e264333d826c",
      "semantic_event:6f422cd4-df63-4c19-abb4-df24f8e04528",
      "semantic_event:0ec3922c-faad-4d56-8a8d-b7a71184c43c"
    ],
    "newer_matches_chronological": true,
    "newer_page_count": 4,
    "older_page_count": 4,
    "returned_to_present_entry_ids": [
      "visible_message:dc8a07c9-8fcf-4b45-8bc3-57d0dbef3d83",
      "visible_message:540ab4ff-c8e0-480c-a986-6b4ad65262f1",
      "visible_message:057d1dde-3aa2-4f4b-b18b-3554015f748e",
      "visible_message:779e1473-d402-4303-bb6c-f61db7ac25e4",
      "visible_message:31b655e1-2928-49ee-91dd-07203d5bc6a2",
      "visible_message:d0d929c8-7940-4755-a98c-cda0c74b94c2",
      "semantic_event:6562148c-d2be-45ee-8df3-a8ccdb5a097e",
      "semantic_event:642062ab-48e3-4392-aace-12b2846d4854",
      "semantic_event:62affd6f-914c-459e-9c99-8b8c1d5ecfad",
      "semantic_event:7ea0069c-0dae-4544-a0ee-e264333d826c",
      "semantic_event:6f422cd4-df63-4c19-abb4-df24f8e04528",
      "semantic_event:0ec3922c-faad-4d56-8a8d-b7a71184c43c"
    ],
    "unique_without_skips": true
  },
  "non_mutation": {
    "persisted_sqlite_state_identical_before_after_gets": true
  },
  "recovery_request": {
    "body": {
      "agent": {
        "association": "probable",
        "binding_revision": 0,
        "capabilities": {
          "association": "probable",
          "chat_send": "unavailable",
          "context": "structured",
          "decision_reply": "open_terminal",
          "delivery_ack": "log_observed"
        },
        "context": {
          "blockers": [],
          "completed_items": [],
          "current_task": "step-6",
          "decisions": [],
          "estimated_completion": null,
          "extraction_health": "ok",
          "goal": "Ship recovery",
          "last_updated": 1788194692.469606,
          "lifecycle": "observing",
          "next_action": "next-6",
          "progress": null,
          "progress_summary": "",
          "provenance": {},
          "revision": 6,
          "runtime": "codex",
          "session_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777"
        },
        "created_at": 1788194692.4659688,
        "extraction_health": "ok",
        "id": "0a391056-b7cb-4bc7-9914-ee4c7b264777",
        "last_event_at": 1788194692.469606,
        "lifecycle": "observing",
        "native_session_id": "native-evidence",
        "pane_id": null,
        "pending_decisions_count": 0,
        "revision": 6,
        "runtime": "codex",
        "target": null,
        "title": "Ship recovery",
        "updated_at": 1788194692.470676
      },
      "changes": {
        "as_of_snapshot_id": "0ec3922c-faad-4d56-8a8d-b7a71184c43c",
        "baseline_snapshot_id": null,
        "basis": "available_history",
        "delta": {
          "current_task_changed": {
            "from": null,
            "to": "step-6"
          },
          "goal_changed": {
            "from": null,
            "to": "Ship recovery"
          },
          "lifecycle_changed": {
            "from": null,
            "to": "observing"
          },
          "next_action_changed": {
            "from": null,
            "to": "next-6"
          }
        },
        "history_truncated": false,
        "unavailable_reason": null
      },
      "consistency": "single_read",
      "freshness": {
        "last_runtime_event_at": 1788194692.469606,
        "model_context": "runtime_owned_unverified",
        "observed_at": null,
        "projected_at": 1788194692.470676,
        "runtime_session": "unknown"
      },
      "generated_at": 1788194692.492723,
      "recent_activity": {
        "coverage": {
          "semantic_history": {
            "history_truncated": false,
            "more_retained_newer": false,
            "more_retained_older": true,
            "retained_from": 1788194692.4696288,
            "retained_to": 1788194692.470676,
            "unavailable_reason": null
          },
          "visible_messages": {
            "history_truncated": false,
            "more_retained_newer": false,
            "more_retained_older": true,
            "retained_from": 1788194692.469606,
            "retained_to": 1788194692.469606,
            "unavailable_reason": null
          }
        },
        "cursor_status": "current",
        "entries": [
          {
            "id": "semantic_event:7ea0069c-0dae-4544-a0ee-e264333d826c",
            "kind": "semantic_event",
            "occurred_at": 1788194692.470282,
            "resource": {
              "agent_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777",
              "context": {
                "blockers": [],
                "completed_items": [],
                "current_task": "step-4",
                "decisions": [],
                "estimated_completion": null,
                "extraction_health": "ok",
                "goal": "Ship recovery",
                "last_updated": 1788194692.469606,
                "lifecycle": "observing",
                "next_action": "next-4",
                "progress": null,
                "progress_summary": "",
                "provenance": {},
                "revision": 4,
                "runtime": "codex",
                "session_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777"
              },
              "created_at": 1788194692.470282,
              "delta": {
                "current_task_changed": {
                  "from": "step-3",
                  "to": "step-4"
                },
                "next_action_changed": {
                  "from": "next-3",
                  "to": "next-4"
                }
              },
              "id": "7ea0069c-0dae-4544-a0ee-e264333d826c",
              "occurred_at": 1788194692.470282,
              "sequence": 4,
              "title": "Agent context changed",
              "type": "context"
            },
            "resource_id": "7ea0069c-0dae-4544-a0ee-e264333d826c"
          },
          {
            "id": "semantic_event:6f422cd4-df63-4c19-abb4-df24f8e04528",
            "kind": "semantic_event",
            "occurred_at": 1788194692.470474,
            "resource": {
              "agent_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777",
              "context": {
                "blockers": [],
                "completed_items": [],
                "current_task": "step-5",
                "decisions": [],
                "estimated_completion": null,
                "extraction_health": "ok",
                "goal": "Ship recovery",
                "last_updated": 1788194692.469606,
                "lifecycle": "observing",
                "next_action": "next-5",
                "progress": null,
                "progress_summary": "",
                "provenance": {},
                "revision": 5,
                "runtime": "codex",
                "session_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777"
              },
              "created_at": 1788194692.470474,
              "delta": {
                "current_task_changed": {
                  "from": "step-4",
                  "to": "step-5"
                },
                "next_action_changed": {
                  "from": "next-4",
                  "to": "next-5"
                }
              },
              "id": "6f422cd4-df63-4c19-abb4-df24f8e04528",
              "occurred_at": 1788194692.470474,
              "sequence": 5,
              "title": "Agent context changed",
              "type": "context"
            },
            "resource_id": "6f422cd4-df63-4c19-abb4-df24f8e04528"
          },
          {
            "id": "semantic_event:0ec3922c-faad-4d56-8a8d-b7a71184c43c",
            "kind": "semantic_event",
            "occurred_at": 1788194692.470676,
            "resource": {
              "agent_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777",
              "context": {
                "blockers": [],
                "completed_items": [],
                "current_task": "step-6",
                "decisions": [],
                "estimated_completion": null,
                "extraction_health": "ok",
                "goal": "Ship recovery",
                "last_updated": 1788194692.469606,
                "lifecycle": "observing",
                "next_action": "next-6",
                "progress": null,
                "progress_summary": "",
                "provenance": {},
                "revision": 6,
                "runtime": "codex",
                "session_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777"
              },
              "created_at": 1788194692.470676,
              "delta": {
                "current_task_changed": {
                  "from": "step-5",
                  "to": "step-6"
                },
                "next_action_changed": {
                  "from": "next-5",
                  "to": "next-6"
                }
              },
              "id": "0ec3922c-faad-4d56-8a8d-b7a71184c43c",
              "occurred_at": 1788194692.470676,
              "sequence": 6,
              "title": "Agent context changed",
              "type": "context"
            },
            "resource_id": "0ec3922c-faad-4d56-8a8d-b7a71184c43c"
          }
        ],
        "newer_cursor": null,
        "older_cursor": "rc1.XQtVf_1rWlpzORe4eyJhIjoxNzg4MTk0NjkyLjQ5MjcyMywiYiI6WzE3ODgxOTQ2OTIuNDcwMjgyLDEsNCwiN2VhMDA2OWMtMGRhZS00NTQ0LWEwZWUtZTI2NDMzM2Q4MjZjIl0sImQiOiJvbGRlciIsImsiOiJhY3Rpdml0eSIsIm0iOjYsInAiOjYsInMiOiIwYTM5MTA1Ni1iN2NiLTRiYzctOTkxNC1lZTRjN2IyNjQ3NzciLCJ2IjoxfQ",
        "order": "oldest_to_newest",
        "tie_break": "occurred_at_kind_source_order_resource_id"
      },
      "recent_messages": {
        "coverage": {
          "history_truncated": false,
          "more_retained_newer": false,
          "more_retained_older": true,
          "retained_from": 1788194692.469606,
          "retained_to": 1788194692.469606,
          "unavailable_reason": null
        },
        "cursor_status": "current",
        "messages": [
          {
            "agent_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777",
            "client_message_id": null,
            "content": "visible message 5",
            "created_at": 1788194692.469606,
            "id": "31b655e1-2928-49ee-91dd-07203d5bc6a2",
            "native_event_id": "visible-5",
            "role": "user",
            "status": "observed",
            "updated_at": 1788194692.470474
          },
          {
            "agent_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777",
            "client_message_id": null,
            "content": "visible message 6",
            "created_at": 1788194692.469606,
            "id": "d0d929c8-7940-4755-a98c-cda0c74b94c2",
            "native_event_id": "visible-6",
            "role": "assistant",
            "status": "observed",
            "updated_at": 1788194692.470676
          }
        ],
        "next_cursor": "rc1.2_22wgyMv5HRJjKzeyJhIjoxNzg4MTk0NjkyLjQ5MjcyMywiYiI6WzE3ODgxOTQ2OTIuNDY5NjA2LDAsNSwiMzFiNjU1ZTEtMjkyOC00OWVlLTkxZGQtMDcyMDNkNWJjNmEyIl0sImQiOiJvbGRlciIsImsiOiJtZXNzYWdlcyIsIm0iOjYsInAiOjYsInMiOiIwYTM5MTA1Ni1iN2NiLTRiYzctOTkxNC1lZTRjN2IyNjQ3NzciLCJ2IjoxfQ",
        "order": "oldest_to_newest",
        "previous_cursor": null
      },
      "recent_timeline": {
        "coverage": {
          "history_truncated": false,
          "more_retained_newer": false,
          "more_retained_older": true,
          "retained_from": 1788194692.4696288,
          "retained_to": 1788194692.470676,
          "unavailable_reason": null
        },
        "cursor_status": "current",
        "events": [
          {
            "agent_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777",
            "context": {
              "blockers": [],
              "completed_items": [],
              "current_task": "step-5",
              "decisions": [],
              "estimated_completion": null,
              "extraction_health": "ok",
              "goal": "Ship recovery",
              "last_updated": 1788194692.469606,
              "lifecycle": "observing",
              "next_action": "next-5",
              "progress": null,
              "progress_summary": "",
              "provenance": {},
              "revision": 5,
              "runtime": "codex",
              "session_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777"
            },
            "created_at": 1788194692.470474,
            "delta": {
              "current_task_changed": {
                "from": "step-4",
                "to": "step-5"
              },
              "next_action_changed": {
                "from": "next-4",
                "to": "next-5"
              }
            },
            "id": "6f422cd4-df63-4c19-abb4-df24f8e04528",
            "occurred_at": 1788194692.470474,
            "sequence": 5,
            "title": "Agent context changed",
            "type": "context"
          },
          {
            "agent_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777",
            "context": {
              "blockers": [],
              "completed_items": [],
              "current_task": "step-6",
              "decisions": [],
              "estimated_completion": null,
              "extraction_health": "ok",
              "goal": "Ship recovery",
              "last_updated": 1788194692.469606,
              "lifecycle": "observing",
              "next_action": "next-6",
              "progress": null,
              "progress_summary": "",
              "provenance": {},
              "revision": 6,
              "runtime": "codex",
              "session_id": "0a391056-b7cb-4bc7-9914-ee4c7b264777"
            },
            "created_at": 1788194692.470676,
            "delta": {
              "current_task_changed": {
                "from": "step-5",
                "to": "step-6"
              },
              "next_action_changed": {
                "from": "next-5",
                "to": "next-6"
              }
            },
            "id": "0ec3922c-faad-4d56-8a8d-b7a71184c43c",
            "occurred_at": 1788194692.470676,
            "sequence": 6,
            "title": "Agent context changed",
            "type": "context"
          }
        ],
        "next_cursor": "rc1.9Be8V4k_GtjRAAVXeyJhIjoxNzg4MTk0NjkyLjQ5MjcyMywiYiI6WzE3ODgxOTQ2OTIuNDcwNDc0LDEsNSwiNmY0MjJjZDQtZGY2My00YzE5LWFiYjQtZGYyNGY4ZTA0NTI4Il0sImQiOiJvbGRlciIsImsiOiJ0aW1lbGluZSIsIm0iOjYsInAiOjYsInMiOiIwYTM5MTA1Ni1iN2NiLTRiYzctOTkxNC1lZTRjN2IyNjQ3NzciLCJ2IjoxfQ",
        "order": "oldest_to_newest",
        "previous_cursor": null
      },
      "server_instance_id": "evidence-server",
      "version": 1
    },
    "cache_control": "no-store, max-age=0",
    "status": 200
  },
  "scenario": "Authenticated iOS-style recovery fetch and bounded cursor traversal",
  "unauthorized_request": {
    "body": {
      "detail": "bad or missing token"
    },
    "cache_control": "no-store, max-age=0",
    "status": 401
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f8556eba9f561646728e49ccd81bbdabce716dca","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (5) ✅</summary>

- 🚨 `vmux/agents/store.py:1137` - Cursor membership incorrectly depends on mutable `updated_at`. After the first page, reconciliation of a locally sent message updates that field, causing every subsequent anchored cursor query to omit the message permanently. Anchor membership using an immutable, non-reusable insertion sequence instead.
- 🚨 `vmux/agents/store.py:1479` - The required “accurate ... freshness” is contradicted by `observed_at: generated_at` and `runtime_session` derived solely from persisted association/lifecycle. After a quiet period or restart where the pane disappeared, recovery reports a fresh observation and `live_bound` before any runtime observation verifies it. Use the latest actual observation or report `unknown`; keep request generation time separate.
- ⚠️ `vmux/server.py:494` - The new documentation promises malformed recovery cursors return 400, but cursors longer than 1000 characters are rejected by FastAPI validation as 422 before `_decode_recovery_cursor` runs. Either route all cursor validation through the decoder or document the distinct status.

🔧 Fix: Verify recovery freshness and cursor error contract
2 errors still open:

- 🚨 `vmux/agents/store.py:1290` - The required “current ... accurate ... freshness” remains violated when a long-lived pane starts a different native session. `submit()` publishes the new pane observation before asynchronous discovery/rebinding, while this check matches only the reusable pane incarnation; recovery can therefore report the old session as `live_bound`. Correlate observations with the discovered native session at the post-projection boundary before asserting liveness.
- 🚨 `vmux/agents/store.py:1417` - The required “accurate ... retention coverage” is contradicted by treating session age as proof that visible messages expired. A session created before the cutoff but containing only newer—or no—messages returns `history_truncated: true` and `expired_or_deleted` without any message loss. Derive this solely from durable message-retention/deletion evidence.

🔧 Fix: Correlate recovery freshness and retention evidence
1 error still open:

- 🚨 `vmux/agents/service.py:645` - The required “current ... freshness” can still be stale: recovery copies a verified observation under `_latest_lock`, releases that lock, and only afterward starts the store read. If `submit()` reports the pane missing or replaced in that gap, it clears verification, but this request still combines the old observation with the persisted confirmed binding and returns `live_bound`. Correlate an observation generation with the completed read (and downgrade if it changed) so pane state and SQLite state represent one observation.

🔧 Fix: Version recovery freshness across concurrent observations
1 error still open:

- 🚨 `vmux/agents/store.py:1251` - The required “current ... accurate ... freshness” still has a reachable stale-liveness path: after one verified observation, repeated `poll_once()` failures occur before `submit()` clears it, and this branch reports `live_bound` indefinitely without checking observation age. Validate freshness in `AgentService.recovery` using the established poll-relative staleness boundary before passing the observation to the store; otherwise return `unknown`.

🔧 Fix: Expire stale recovery liveness observations
1 error still open:

- 🚨 `vmux/agents/store.py:1353` - The required “accurate available changes” are wrong after retention when no Review/visit baseline exists. If early snapshots expired, this branch marks truncation only after the fallback-to-oldest check, so `baseline` remains null and `semantic_delta({}, current)` fabricates changes already present in the oldest retained context. Use the oldest retained snapshot as the effective baseline whenever `available_history` is truncated.

🔧 Fix: Correct truncated recovery change baselines
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `uv run pytest tests/test_recovery.py -q`
- <code>`uv run python -c &#39;&lt;focused FastAPI TestClient recovery scenario&gt;&#39;` — exercised authentication, capability advertisement, structured recovery response, older/newer traversal, cache headers, and persisted-state non-mutation</code>
- `jq '{scenario, unauthorized_request, capability_request, recovery: {...}, cursor_traversal, non_mutation}' /Users/rlalpha/.no-mistakes/evidence/01M1C96Z99ZJ8BWH1NGRBY09GH/recovery-api-e2e.json`
- `git status --short`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
